### PR TITLE
This fixes an issue with SNMPV3 AES192/AES256 privacy support for Cis…

### DIFF
--- a/pysnmp/proto/secmod/eso/priv/aesbase.py
+++ b/pysnmp/proto/secmod/eso/priv/aesbase.py
@@ -7,6 +7,7 @@
 from pysnmp.proto.secmod.rfc3826.priv import aes
 from pysnmp.proto.secmod.rfc3414.auth import hmacmd5, hmacsha
 from pysnmp.proto.secmod.rfc3414 import localkey
+from pysnmp.proto.secmod.rfc3414.localkey import hashPassphraseMD5,localizeKeyMD5,hashPassphraseSHA,localizeKeySHA
 from pysnmp.proto import error
 from math import ceil
 
@@ -25,19 +26,47 @@ class AbstractAes(aes.Aes):
     keySize = 0
 
     # 3.1.2.1
+    # def localizeKey(self, authProtocol, privKey, snmpEngineID):
+    #     if authProtocol == hmacmd5.HmacMd5.serviceID:
+    #         localPrivKey = localkey.localizeKeyMD5(privKey, snmpEngineID)
+    #         for count in range(1, int(ceil(self.keySize * 1.0 / len(localPrivKey)))):
+    #             # noinspection PyDeprecation,PyCallingNonCallable
+    #             localPrivKey += md5(localPrivKey).digest()
+    #     elif authProtocol == hmacsha.HmacSha.serviceID:
+    #         localPrivKey = localkey.localizeKeySHA(privKey, snmpEngineID)
+    #         # RFC mentions this algo generates 480bit key, but only up to 256 bits are used
+    #         for count in range(1, int(ceil(self.keySize * 1.0 / len(localPrivKey)))):
+    #             localPrivKey += sha1(localPrivKey).digest()
+    #     else:
+    #         raise error.ProtocolError(
+    #             'Unknown auth protocol %s' % (authProtocol,)
+    #         )
+    #     return localPrivKey[:self.keySize]
+
+
+    #Cisco devices do not use https://tools.itef.org/pdf/draft_bluementhal-aes-usm-04.txt for key localization
+    #instead, they use the procedure for 3DES key localization specified in
+    #https://tools.itef.org/pdf/draft_reeder_snmpv3-usm-3desede-00.pdf
+    #the difference between the two is that the reeder draft does key extension by repeating the steps
+    #in the password to key alogorithm (hash phrase, then localize with SNMPEngine ID)
+    #Should this library support both key localization methods by some mechanism?
+    #Are there non-cisco devices out there that support the key localization for AES192/AES256 in https://tools.itef.org/pdf/draft_bluementhal-aes-usm-04.txt?
+    #Pysnmp Maintainers can decide this.
     def localizeKey(self, authProtocol, privKey, snmpEngineID):
         if authProtocol == hmacmd5.HmacMd5.serviceID:
             localPrivKey = localkey.localizeKeyMD5(privKey, snmpEngineID)
-            for count in range(1, int(ceil(self.keySize * 1.0 / len(localPrivKey)))):
-                # noinspection PyDeprecation,PyCallingNonCallable
-                localPrivKey += md5(localPrivKey).digest()
+            #now extend this key if too short by repeating steps that includes the hashPassphrase step
+            while (len(localPrivKey) < self.keySize):
+                newKey = hashPassphraseMD5(localPrivKey) #this is the difference between reeder and bluementhal
+                localPrivKey = localPrivKey + localizeKeyMD5(newKey, snmpEngineID)
         elif authProtocol == hmacsha.HmacSha.serviceID:
             localPrivKey = localkey.localizeKeySHA(privKey, snmpEngineID)
-            # RFC mentions this algo generates 480bit key, but only up to 256 bits are used
-            for count in range(1, int(ceil(self.keySize * 1.0 / len(localPrivKey)))):
-                localPrivKey += sha1(localPrivKey).digest()
+            while (len(localPrivKey) < self.keySize):
+                newKey = hashPassphraseSHA(localPrivKey)
+                localPrivKey = localPrivKey + localizeKeySHA(newKey, snmpEngineID)
         else:
             raise error.ProtocolError(
                 'Unknown auth protocol %s' % (authProtocol,)
             )
         return localPrivKey[:self.keySize]
+

--- a/pysnmp/proto/secmod/eso/priv/aesbase.py
+++ b/pysnmp/proto/secmod/eso/priv/aesbase.py
@@ -7,7 +7,6 @@
 from pysnmp.proto.secmod.rfc3826.priv import aes
 from pysnmp.proto.secmod.rfc3414.auth import hmacmd5, hmacsha
 from pysnmp.proto.secmod.rfc3414 import localkey
-from pysnmp.proto.secmod.rfc3414.localkey import hashPassphraseMD5,localizeKeyMD5,hashPassphraseSHA,localizeKeySHA
 from pysnmp.proto import error
 from math import ceil
 
@@ -56,14 +55,14 @@ class AbstractAes(aes.Aes):
         if authProtocol == hmacmd5.HmacMd5.serviceID:
             localPrivKey = localkey.localizeKeyMD5(privKey, snmpEngineID)
             #now extend this key if too short by repeating steps that includes the hashPassphrase step
-            while (len(localPrivKey) < self.keySize):
-                newKey = hashPassphraseMD5(localPrivKey) #this is the difference between reeder and bluementhal
-                localPrivKey = localPrivKey + localizeKeyMD5(newKey, snmpEngineID)
+            while len(localPrivKey) < self.keySize:
+                newKey = localkey.hashPassphraseMD5(localPrivKey) #this is the difference between reeder and bluementhal
+                localPrivKey += localkey.localizeKeyMD5(newKey, snmpEngineID)
         elif authProtocol == hmacsha.HmacSha.serviceID:
             localPrivKey = localkey.localizeKeySHA(privKey, snmpEngineID)
-            while (len(localPrivKey) < self.keySize):
-                newKey = hashPassphraseSHA(localPrivKey)
-                localPrivKey = localPrivKey + localizeKeySHA(newKey, snmpEngineID)
+            while len(localPrivKey) < self.keySize:
+                newKey = localkey.hashPassphraseSHA(localPrivKey)
+                localPrivKey +=  localkey.localizeKeySHA(newKey, snmpEngineID)
         else:
             raise error.ProtocolError(
                 'Unknown auth protocol %s' % (authProtocol,)


### PR DESCRIPTION
…co devices. However, this raises a sticky issue on how this should actually be done within Psynmp, so this pull request is to make the Pysnmp maintainers aware of this issue.

Issue: Pysnmp SNMPV3 AES192/AES256 privacy options does not work for Cisco devices (test this with any Cisco device running an IOS that suppports AES192/AES256).

This is because Cisco devices (ie, IOS that supports AES192/AES256) do not use 
https://tools.ietf.org/html/draft-blumenthal-aes-usm-04 for key localization/short key extension.
Instead, they use the procedure for 3DES key localization specified in https://tools.ietf.org/html/draft-reeder-snmpv3-usm-3desede-00 which
specifies the 3DES key localization/short key extension. I believe Cisco did this because they view the reeder mechanism as an improvement over the bluementhal mechanism.
However, this breaks tools that use the blumenthal mechanism (i.e. try either SNMPSoft SnmpGet or SNMP++ with a Cisco IOS device, AES192/AES256 options on these tools do not work with CISCO devices since they use the bluementhal mechanism for key localization/short key extension).

1. Should the Psynmp library support both key localization methods by some mechanism? (maybe an optional argument at the top level API?)
2. Are there actually non-cisco devices out there that support the key localization for AES192/AES256? If yes, then Pysnmp needs to support both methods.

Pysnmp maintainers can decide this issue.  I would be happy to add support for both key localization mechanism if given direction on how the Pysnmp maintainers want to do this.  I am currently using this fix on my own project as I need to talk to Cisco devices with AES192/AES256 privacy. 

This code change has been tested with Cisco IOS 15.1 (Cisco 890 Integrated Services Router) and Cisco Modeling Labs (IOS 15.4).
This code change breaks compatibility with any device that does SNMPV3 AES192/AES256 key localization via https://tools.ietf.org/html/draft-blumenthal-aes-usm-04