### PR TITLE
Add explicit Python version support classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,15 @@ License :: OSI Approved :: BSD License
 Natural Language :: English
 Operating System :: OS Independent
 Programming Language :: Python :: 2
+Programming Language :: Python :: 2.4
+Programming Language :: Python :: 2.5
+Programming Language :: Python :: 2.6
+Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
+Programming Language :: Python :: 3.2
+Programming Language :: Python :: 3.3
+Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3.5
 Topic :: Communications
 Topic :: Software Development :: Libraries :: Python Modules
 Topic :: System :: Monitoring


### PR DESCRIPTION
Matches what is stated in the README (though 2.4-2.5 are not tested on Travis).