### PR TITLE
Use pip to install local package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ python:
 install:
   - pip install -r requirements.txt
   - pip install pysnmp-mibs
-  - python setup.py install
+  - pip install --no-deps .
 script:
   - sh runtests.sh


### PR DESCRIPTION
Follows `pip` guidance in the warnings [here](https://pip.pypa.io/en/stable/reference/pip_install/#hash-checking-mode) to avoid `python setup.py install`.  Probably of minor importance on Travis, but keeps the install more consistently all using `pip`.