### PR TITLE
Removed tuple unpacking in function signatures in twisted 

### DIFF
--- a/examples/hlapi/twisted/agent/ntforg/default-v1-trap.py
+++ b/examples/hlapi/twisted/agent/ntforg/default-v1-trap.py
@@ -24,7 +24,9 @@ from twisted.internet.task import react
 from pysnmp.hlapi.twisted import *
 
 
-def success((errorStatus, errorIndex, varBinds), hostname):
+def success(args, hostname):
+    (errorStatus, errorIndex, varBinds) = args
+
     if errorStatus:
         print('%s: %s at %s' % (
             hostname,

--- a/examples/hlapi/twisted/agent/ntforg/multiple-notifications-at-once.py
+++ b/examples/hlapi/twisted/agent/ntforg/multiple-notifications-at-once.py
@@ -27,7 +27,9 @@ from twisted.internet.task import react
 from pysnmp.hlapi.twisted import *
 
 
-def success((errorStatus, errorIndex, varBinds), hostname):
+def success(args, hostname):
+    (errorStatus, errorIndex, varBinds) = args
+
     if errorStatus:
         print('%s: %s at %s' % (hostname,
                                 errorStatus.prettyPrint(),

--- a/examples/hlapi/twisted/manager/cmdgen/custom-timeout-and-retries.py
+++ b/examples/hlapi/twisted/manager/cmdgen/custom-timeout-and-retries.py
@@ -19,7 +19,9 @@ from twisted.internet.task import react
 from pysnmp.hlapi.twisted import *
 
 
-def success((errorStatus, errorIndex, varBinds), hostname):
+def success(args, hostname):
+    (errorStatus, errorIndex, varBinds) = args
+
     if errorStatus:
         print('%s: %s at %s' % (hostname,
                                 errorStatus.prettyPrint(),

--- a/examples/hlapi/twisted/manager/cmdgen/getbulk-to-eom.py
+++ b/examples/hlapi/twisted/manager/cmdgen/getbulk-to-eom.py
@@ -20,7 +20,9 @@ from twisted.internet.task import react
 from pysnmp.hlapi.twisted import *
 
 
-def success((errorStatus, errorIndex, varBindTable), reactor, snmpEngine):
+def success(args, reactor, snmpEngine):
+    (errorStatus, errorIndex, varBindTable) = args
+
     if errorStatus:
         print('%s: %s at %s' % (hostname,
                                 errorStatus.prettyPrint(),

--- a/examples/hlapi/twisted/manager/cmdgen/multiple-concurrent-queries.py
+++ b/examples/hlapi/twisted/manager/cmdgen/multiple-concurrent-queries.py
@@ -23,7 +23,7 @@ from pysnmp.hlapi.twisted import *
 
 
 def success(args, hostname):
-    (errorStatus, errorIndex, varBindTable) = args
+    (errorStatus, errorIndex, varBinds) = args
 
     if errorStatus:
         print('%s: %s at %s' % (hostname,

--- a/examples/hlapi/twisted/manager/cmdgen/multiple-concurrent-queries.py
+++ b/examples/hlapi/twisted/manager/cmdgen/multiple-concurrent-queries.py
@@ -22,7 +22,9 @@ from twisted.internet.task import react
 from pysnmp.hlapi.twisted import *
 
 
-def success((errorStatus, errorIndex, varBinds), hostname):
+def success(args, hostname):
+    (errorStatus, errorIndex, varBindTable) = args
+
     if errorStatus:
         print('%s: %s at %s' % (hostname,
                                 errorStatus.prettyPrint(),

--- a/examples/hlapi/twisted/manager/cmdgen/pull-mibs-from-multiple-agents-at-once.py
+++ b/examples/hlapi/twisted/manager/cmdgen/pull-mibs-from-multiple-agents-at-once.py
@@ -20,7 +20,9 @@ from twisted.internet.task import react
 from pysnmp.hlapi.twisted import *
 
 
-def success((errorStatus, errorIndex, varBindTable), reactor, snmpEngine, hostname):
+def success(args, reactor, snmpEngine, hostname):
+    (errorStatus, errorIndex, varBindTable) = args
+
     if errorStatus:
         print('%s: %s at %s' % (hostname,
                                 errorStatus.prettyPrint(),

--- a/examples/hlapi/twisted/manager/cmdgen/pull-whole-mib.py
+++ b/examples/hlapi/twisted/manager/cmdgen/pull-whole-mib.py
@@ -19,7 +19,9 @@ from twisted.internet.task import react
 from pysnmp.hlapi.twisted import *
 
 
-def success((errorStatus, errorIndex, varBindTable), reactor, snmpEngine):
+def success(args, reactor, snmpEngine):
+    (errorStatus, errorIndex, varBindTable) = args
+
     if errorStatus:
         print('%s: %s at %s' % (hostname,
                                 errorStatus.prettyPrint(),

--- a/examples/hlapi/twisted/manager/cmdgen/v1-get.py
+++ b/examples/hlapi/twisted/manager/cmdgen/v1-get.py
@@ -19,7 +19,9 @@ from twisted.internet.task import react
 from pysnmp.hlapi.twisted import *
 
 
-def success((errorStatus, errorIndex, varBinds), hostname):
+def success(args, hostname):
+    (errorStatus, errorIndex, varBinds) = args
+
     if errorStatus:
         print('%s: %s at %s' % (hostname,
                                 errorStatus.prettyPrint(),

--- a/pysnmp/carrier/twisted/base.py
+++ b/pysnmp/carrier/twisted/base.py
@@ -21,4 +21,4 @@ class AbstractTwistedTransport(AbstractTransport):
 
     def __init__(self, sock=None, sockMap=None):
         self._writeQ = []
-        DgramTwistedTransport.__init__(self)
+#        DgramTwistedTransport.__init__(self)

--- a/pysnmp/hlapi/twisted/cmdgen.py
+++ b/pysnmp/hlapi/twisted/cmdgen.py
@@ -88,7 +88,8 @@ def getCmd(snmpEngine, authData, transportTarget, contextData,
     >>> from twisted.internet.task import react
     >>> from pysnmp.hlapi.twisted import *
     >>>
-    >>> def success((errorStatus, errorIndex, varBinds)):
+    >>> def success(args):
+    ...     (errorStatus, errorIndex, varBinds) = args
     ...     print(errorStatus, errorIndex, varBind)
     ...
     >>> def failure(errorIndication):
@@ -199,7 +200,8 @@ def setCmd(snmpEngine, authData, transportTarget, contextData,
     >>> from twisted.internet.task import react
     >>> from pysnmp.hlapi.twisted import *
     >>>
-    >>> def success((errorStatus, errorIndex, varBinds)):
+    >>> def success(args):
+    ...     (errorStatus, errorIndex, varBinds) = args
     ...     print(errorStatus, errorIndex, varBind)
     ...
     >>> def failure(errorIndication):
@@ -314,7 +316,8 @@ def nextCmd(snmpEngine, authData, transportTarget, contextData,
     >>> from twisted.internet.task import react
     >>> from pysnmp.hlapi.twisted import *
     >>>
-    >>> def success((errorStatus, errorIndex, varBindTable)):
+    >>> def success(args):
+    ...     (errorStatus, errorIndex, varBinds) = args
     ...     print(errorStatus, errorIndex, varBindTable)
     ...
     >>> def failure(errorIndication):
@@ -439,7 +442,8 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
     >>> from twisted.internet.task import react
     >>> from pysnmp.hlapi.twisted import *
     >>>
-    >>> def success((errorStatus, errorIndex, varBindTable)):
+    >>> def success(args):
+    ...     (errorStatus, errorIndex, varBinds) = args
     ...     print(errorStatus, errorIndex, varBindTable)
     ...
     >>> def failure(errorIndication):

--- a/pysnmp/hlapi/twisted/cmdgen.py
+++ b/pysnmp/hlapi/twisted/cmdgen.py
@@ -317,7 +317,7 @@ def nextCmd(snmpEngine, authData, transportTarget, contextData,
     >>> from pysnmp.hlapi.twisted import *
     >>>
     >>> def success(args):
-    ...     (errorStatus, errorIndex, varBinds) = args
+    ...     (errorStatus, errorIndex, varBindTable) = args
     ...     print(errorStatus, errorIndex, varBindTable)
     ...
     >>> def failure(errorIndication):
@@ -443,7 +443,7 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
     >>> from pysnmp.hlapi.twisted import *
     >>>
     >>> def success(args):
-    ...     (errorStatus, errorIndex, varBinds) = args
+    ...     (errorStatus, errorIndex, varBindTable) = args
     ...     print(errorStatus, errorIndex, varBindTable)
     ...
     >>> def failure(errorIndication):

--- a/pysnmp/hlapi/twisted/ntforg.py
+++ b/pysnmp/hlapi/twisted/ntforg.py
@@ -95,7 +95,8 @@ def sendNotification(snmpEngine, authData, transportTarget, contextData,
     >>> from twisted.internet.task import react
     >>> from pysnmp.hlapi.twisted import *
     >>>
-    >>> def success((errorStatus, errorIndex, varBinds)):
+    >>> def success(args):
+    ...     (errorStatus, errorIndex, varBinds) = args
     ...     print(errorStatus, errorIndex, varBind)
     ...
     >>> def failure(errorIndication):


### PR DESCRIPTION
Since tuple unpacking in function signatures is [no longer supported in Python3](https://www.python.org/dev/peps/pep-3113/), the twisted parts won't work in Python3.  

I realize Twisted itself is not fully ported to Python3, but the Pysnmp parts seems to work anyway.

The [examples](http://pysnmp.sourceforge.net/docs/api-reference.html#asynchronous-twisted) should be updated as well, but I didn't know how to do that.

I also commented out the last line [here](https://github.com/gerrat/pysnmp/blob/master/pysnmp/carrier/twisted/base.py).  This may not be the right fix, but that module can't be imported as-is.
