### PR TITLE
Fix IndexError in makeVarBinds.

### DIFF
--- a/pysnmp/hlapi/varbinds.py
+++ b/pysnmp/hlapi/varbinds.py
@@ -33,6 +33,8 @@ class CommandGeneratorVarBinds(AbstractVarBinds):
                 varBind = ObjectType(*varBind)
             elif isinstance(varBind[0][0], tuple):  # legacy
                 varBind = ObjectType(ObjectIdentity(varBind[0][0][0], varBind[0][0][1], *varBind[0][1:]), varBind[1])
+            elif isinstance(varBind[0], ObjectType) and len(varBind) == 1:
+                varBind = varBind[0]
             else:
                 varBind = ObjectType(ObjectIdentity(varBind[0]), varBind[1])
 


### PR DESCRIPTION
 * Communication with a DD-WRT router running UCD-SNMP previously
   resulted in a single-element list, which caused an `IndexError` to be
   raised when `varBind[1]` was accessed.
 * The following is an example `varBind` object exhibiting the issue:
```
       [ObjectType(
            ObjectIdentity(ObjectName('1.3.6.1.2.1.1.9.1.4.6')),
            TimeStamp(1))
       ]
```