### PR TITLE
Fixed issue on windows with engine-boots not properly being written.

### DIFF
--- a/pysnmp/entity/engine.py
+++ b/pysnmp/entity/engine.py
@@ -5,6 +5,7 @@
 # License: http://pysnmp.sf.net/license.html
 #
 import os
+import shutil
 import sys
 import tempfile
 from pyasn1.compat.octets import str2octs
@@ -132,7 +133,7 @@ class SnmpEngine(object):
                 fd, fn = tempfile.mkstemp(dir=persistentPath)
                 os.write(fd, str2octs(snmpEngineBoots.syntax.prettyPrint()))
                 os.close(fd)
-                os.rename(fn, f)
+                shutil.move(fn, f)
             except Exception:
                 debug.logger & debug.flagApp and debug.logger(
                     'SnmpEngine: could not stored SNMP Engine Boots: %s' % sys.exc_info()[1])


### PR DESCRIPTION
There was an issue where engine boots was not properly being written on Windows because the _os.rename()_ will throw an exception when renaming to a file that exists. It is described here:

https://stackoverflow.com/questions/8107352/force-overwrite-in-os-rename

_shutil.move()_ should maintain the same atomic renaming on linux as it uses _os.rename_ underneath (https://docs.python.org/2/library/shutil.html#shutil.move), but it also works on windows.