### PR TITLE
Catch and pass exceptions to asyncio futures

### DIFF
--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -134,9 +134,15 @@ def getCmd(snmpEngine, authData, transportTarget, contextData,
         lookupMib, future = cbCtx
         if future.cancelled():
             return
-        future.set_result(
-            (errorIndication, errorStatus, errorIndex, vbProcessor.unmakeVarBinds(snmpEngine, varBinds, lookupMib))
-        )
+        try:
+            varBindsUnmade = vbProcessor.unmakeVarBinds(snmpEngine, varBinds,
+                                                        lookupMib)
+        except Exception as e:
+            future.set_exception(e)
+        else:
+            future.set_result(
+                (errorIndication, errorStatus, errorIndex, varBindsUnmade)
+            )
 
     addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
 
@@ -233,9 +239,15 @@ def setCmd(snmpEngine, authData, transportTarget, contextData,
         lookupMib, future = cbCtx
         if future.cancelled():
             return
-        future.set_result(
-            (errorIndication, errorStatus, errorIndex, vbProcessor.unmakeVarBinds(snmpEngine, varBinds, lookupMib))
-        )
+        try:
+            varBindsUnmade = vbProcessor.unmakeVarBinds(snmpEngine, varBinds,
+                                                        lookupMib)
+        except Exception as e:
+            future.set_exception(e)
+        else:
+            future.set_result(
+                (errorIndication, errorStatus, errorIndex, varBindsUnmade)
+            )
 
     addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
 
@@ -336,10 +348,17 @@ def nextCmd(snmpEngine, authData, transportTarget, contextData,
         lookupMib, future = cbCtx
         if future.cancelled():
             return
-        future.set_result(
-            (errorIndication, errorStatus, errorIndex,
-             [vbProcessor.unmakeVarBinds(snmpEngine, varBindTableRow, lookupMib) for varBindTableRow in varBindTable])
-        )
+        try:
+            varBindsUnmade = [vbProcessor.unmakeVarBinds(snmpEngine,
+                                                         varBindTableRow,
+                                                         lookupMib)
+                              for varBindTableRow in varBindTable]
+        except Exception as e:
+            future.set_exception(e)
+        else:
+            future.set_result(
+                (errorIndication, errorStatus, errorIndex, varBindsUnmade)
+            )
 
     addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
 
@@ -451,10 +470,17 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
         lookupMib, future = cbCtx
         if future.cancelled():
             return
-        future.set_result(
-            (errorIndication, errorStatus, errorIndex,
-             [vbProcessor.unmakeVarBinds(snmpEngine, varBindTableRow, lookupMib) for varBindTableRow in varBindTable])
-        )
+        try:
+            varBindsUnmade = [vbProcessor.unmakeVarBinds(snmpEngine,
+                                                         varBindTableRow,
+                                                         lookupMib)
+                              for varBindTableRow in varBindTable]
+        except Exception as e:
+            future.set_exception(e)
+        else:
+            future.set_result(
+                (errorIndication, errorStatus, errorIndex, varBindsUnmade)
+            )
 
     addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
 

--- a/pysnmp/hlapi/asyncio/ntforg.py
+++ b/pysnmp/hlapi/asyncio/ntforg.py
@@ -124,9 +124,15 @@ def sendNotification(snmpEngine, authData, transportTarget, contextData,
         lookupMib, future = cbCtx
         if future.cancelled():
             return
-        future.set_result(
-            (errorIndication, errorStatus, errorIndex, vbProcessor.unmakeVarBinds(snmpEngine, varBinds, lookupMib))
-        )
+        try:
+            varBindsUnmade = vbProcessor.unmakeVarBinds(snmpEngine, varBinds,
+                                                        lookupMib)
+        except Exception as e:
+            future.set_exception(e)
+        else:
+            future.set_result(
+                    (errorIndication, errorStatus, errorIndex, varBindsUnmade)
+            )
 
     notifyName = lcd.configure(
         snmpEngine, authData, transportTarget, notifyType


### PR DESCRIPTION
Previously an exception raised by vbProcessor.unmakeVarBinds() fell
through, and asyncio base event loop caught and reported it on stderr,
while the original cmdgen's future went unfinished, causing the call to
hang forever.  Match the synchronous version's behavior, which is to
raise the exception for the caller of the cmdgen to catch.