### PR TITLE
Fix implied string index rendering

### DIFF
--- a/pysnmp/smi/mibs/SNMPv2-SMI.py
+++ b/pysnmp/smi/mibs/SNMPv2-SMI.py
@@ -1006,7 +1006,7 @@ class MibTableRow(MibTree):
         elif baseTag == self.__strBaseTag:
             # rfc1902, 7.7
             if impliedFlag:
-                return obj.clone(value), ()
+                return obj.clone(tuple(value)), ()
             elif obj.isFixedLength():
                 l = obj.getFixedLength()
                 return obj.clone(tuple(value[:l])), value[l:]


### PR DESCRIPTION
Commit 30167082cd3f2706f733168da8647bbc4126696d fixed string index
rendering except for implied string types, which were left broken.
Close that gap by applying the same workaround.