### PR TITLE
Fix OID type matching in ObjectType.resolveWithMib

### DIFF
--- a/pysnmp/smi/rfc1902.py
+++ b/pysnmp/smi/rfc1902.py
@@ -868,7 +868,7 @@ class ObjectType(object):
                 self.__args[0].prettyPrint(), self.__args[0].getMibNode().getSyntax().__class__.__name__, self.__args[1],
                 sys.exc_info()[1]))
 
-        if self.__args[1].isSuperTypeOf(rfc1902.ObjectIdentifier(), matchConstraints=False):
+        if rfc1902.ObjectIdentifier().isSuperTypeOf(self.__args[1], matchConstraints=False):
             self.__args[1] = ObjectIdentity(self.__args[1]).resolveWithMib(mibViewController)
 
         self.__state |= self.stClean


### PR DESCRIPTION
That is, reverse the supertype-subtype direction in the type matching
call: Previously it was checking if the value was a supertype of OID,
whereas the correct check should be whether the value is a subtype of
OID.  This had gone undetected so far because all values were of simple,
tagged types, and if a value is not an OID, their tag set differed, i.e.
neither is a subtype of the other.

Recent introduction of NetworkAddress revealed this bug: Being an
untagged Choice type, NetworkAddress's tag set is empty, and it counts
as a supertype of OID: resolveWithMib() then erroneously treated it as
an OID.