### PR TITLE
Improve documentation of varBindTable returned by bulkCmd()

### DIFF
--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -477,7 +477,7 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
     ...     print(errorIndication, errorStatus, errorIndex, varBinds)
     >>>
     >>> asyncio.get_event_loop().run_until_complete(run())
-    (None, 0, 0, [[ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.1.0')), DisplayString('SunOS zeus.snmplabs.com 4.1.3_U1 1 sun4m')), ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.2.0')), ObjectIdentifier('1.3.6.1.4.1.424242.1.1')]])
+    (None, 0, 0, [[ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.1.0')), DisplayString('SunOS zeus.snmplabs.com 4.1.3_U1 1 sun4m'))], [ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.2.0')), ObjectIdentifier('1.3.6.1.4.1.424242.1.1'))]])
     >>>
 
     """

--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -449,7 +449,7 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
           successor exists.
 
         See :rfc:`3416#section-4.2.3` for details on the underlying
-        `GetBulkRequest-PDU` and the associated `GetResponse-PDU`, such as
+        ``GetBulkRequest-PDU`` and the associated ``GetResponse-PDU``, such as
         specific conditions under which the server may truncate the response,
         causing ``varBindTable`` to have less than ``maxRepetitions`` rows.
 

--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -427,13 +427,31 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
         True value indicates SNMP PDU error.
     errorIndex : int
         Non-zero value refers to `varBinds[errorIndex-1]`
-    varBinds : tuple
+    varBindTable : tuple
         A sequence of sequences (e.g. 2-D array) of
         :py:class:`~pysnmp.smi.rfc1902.ObjectType` class instances
-        representing a table of MIB variables returned in SNMP response.
-        Inner sequences represent table rows and ordered exactly the same
-        as `varBinds` in request. Response to GETNEXT always contain
-        a single row.
+        representing a table of MIB variables returned in SNMP response, with
+        up to ``maxRepetitions`` rows, i.e.
+        ``len(varBindTable) <= maxRepetitions``.
+
+        For ``0 <= i < len(varBindTable)`` and ``0 <= j < len(varBinds)``,
+        ``varBindTable[i][j]`` represents:
+
+        - For non-repeaters (``j < nonRepeaters``), the first lexicographic
+          successor of ``varBinds[j]``, regardless the value of ``i``, or an
+          :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
+          :py:obj:`pysnmp.proto.rfc1905.endOfMibView` value if no such
+          successor exists;
+        - For repeaters (``j >= nonRepeaters``), the ``i``-th lexicographic
+          successor of ``varBinds[j]``, or an
+          :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
+          :py:obj:`pysnmp.proto.rfc1905.endOfMibView` value if no such
+          successor exists.
+
+        See :rfc:`3416#section-4.2.3` for details on the underlying
+        `GetBulkRequest-PDU` and the associated `GetResponse-PDU`, such as
+        specific conditions under which the server may truncate the response,
+        causing ``varBindTable`` to have less than ``maxRepetitions`` rows.
 
     Raises
     ------

--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -440,12 +440,12 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
         - For non-repeaters (``j < nonRepeaters``), the first lexicographic
           successor of ``varBinds[j]``, regardless the value of ``i``, or an
           :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
-          :py:obj:`pysnmp.proto.rfc1905.endOfMibView` value if no such
+          :py:obj:`~pysnmp.proto.rfc1905.endOfMibView` value if no such
           successor exists;
         - For repeaters (``j >= nonRepeaters``), the ``i``-th lexicographic
           successor of ``varBinds[j]``, or an
           :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
-          :py:obj:`pysnmp.proto.rfc1905.endOfMibView` value if no such
+          :py:obj:`~pysnmp.proto.rfc1905.endOfMibView` value if no such
           successor exists.
 
         See :rfc:`3416#section-4.2.3` for details on the underlying

--- a/pysnmp/hlapi/asyncore/cmdgen.py
+++ b/pysnmp/hlapi/asyncore/cmdgen.py
@@ -428,12 +428,12 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
       - For non-repeaters (``j < nonRepeaters``), the first lexicographic
         successor of ``varBinds[j]``, regardless the value of ``i``, or an
         :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
-        :py:obj:`pysnmp.proto.rfc1905.endOfMibView` value if no such successor
+        :py:obj:`~pysnmp.proto.rfc1905.endOfMibView` value if no such successor
         exists;
       - For repeaters (``j >= nonRepeaters``), the ``i``-th lexicographic
         successor of ``varBinds[j]``, or an
         :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
-        :py:obj:`pysnmp.proto.rfc1905.endOfMibView` value if no such successor
+        :py:obj:`~pysnmp.proto.rfc1905.endOfMibView` value if no such successor
         exists.
 
       See :rfc:`3416#section-4.2.3` for details on the underlying

--- a/pysnmp/hlapi/asyncore/cmdgen.py
+++ b/pysnmp/hlapi/asyncore/cmdgen.py
@@ -437,7 +437,7 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
         exists.
 
       See :rfc:`3416#section-4.2.3` for details on the underlying
-      `GetBulkRequest-PDU` and the associated `GetResponse-PDU`, such as
+      ``GetBulkRequest-PDU`` and the associated ``GetResponse-PDU``, such as
       specific conditions under which the server may truncate the response,
       causing ``varBindTable`` to have less than ``maxRepetitions`` rows.
     * `cbCtx` : Original user-supplied object.

--- a/pysnmp/hlapi/asyncore/cmdgen.py
+++ b/pysnmp/hlapi/asyncore/cmdgen.py
@@ -469,7 +469,7 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
     ...         ObjectType(ObjectIdentity('SNMPv2-MIB', 'system')),
     ...         cbFun=cbFun)
     >>> snmpEngine.transportDispatcher.runDispatcher()
-    (None, 0, 0, [ [ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.1.0')), DisplayString('SunOS zeus.snmplabs.com 4.1.3_U1 1 sun4m')), ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.2.0')), ObjectIdentifier('1.3.6.1.4.1.424242.1.1')] ])
+    (None, 0, 0, [[ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.1.0')), DisplayString('SunOS zeus.snmplabs.com 4.1.3_U1 1 sun4m'))], [ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.2.0')), ObjectIdentifier('1.3.6.1.4.1.424242.1.1'))]])
     >>>
 
     """

--- a/pysnmp/hlapi/asyncore/cmdgen.py
+++ b/pysnmp/hlapi/asyncore/cmdgen.py
@@ -416,12 +416,30 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
     * errorIndication (str): True value indicates SNMP engine error.
     * errorStatus (str): True value indicates SNMP PDU error.
     * errorIndex (int): Non-zero value refers to `varBinds[errorIndex-1]`
-    * varBinds (tuple): A sequence of sequences (e.g. 2-D array) of
-      :py:class:`~pysnmp.smi.rfc1902.ObjectType` class instances
-      representing a table of MIB variables returned in SNMP response.
-      Inner sequences represent table rows and ordered exactly the same
-      as `varBinds` in request. Number of rows might be less or equal
-      to `maxRepetitions` value in request.
+    * varBindTable (tuple):
+      A sequence of sequences (e.g. 2-D array) of
+      :py:class:`~pysnmp.smi.rfc1902.ObjectType` class instances representing a
+      table of MIB variables returned in SNMP response, with up to
+      ``maxRepetitions`` rows, i.e. ``len(varBindTable) <= maxRepetitions``.
+
+      For ``0 <= i < len(varBindTable)`` and ``0 <= j < len(varBinds)``,
+      ``varBindTable[i][j]`` represents:
+
+      - For non-repeaters (``j < nonRepeaters``), the first lexicographic
+        successor of ``varBinds[j]``, regardless the value of ``i``, or an
+        :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
+        :py:obj:`pysnmp.proto.rfc1905.endOfMibView` value if no such successor
+        exists;
+      - For repeaters (``j >= nonRepeaters``), the ``i``-th lexicographic
+        successor of ``varBinds[j]``, or an
+        :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
+        :py:obj:`pysnmp.proto.rfc1905.endOfMibView` value if no such successor
+        exists.
+
+      See :rfc:`3416#section-4.2.3` for details on the underlying
+      `GetBulkRequest-PDU` and the associated `GetResponse-PDU`, such as
+      specific conditions under which the server may truncate the response,
+      causing ``varBindTable`` to have less than ``maxRepetitions`` rows.
     * `cbCtx` : Original user-supplied object.
 
     Returns

--- a/pysnmp/hlapi/twisted/cmdgen.py
+++ b/pysnmp/hlapi/twisted/cmdgen.py
@@ -504,7 +504,7 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
     ...     return d
     ...
     >>> react(run)
-    (0, 0, [[ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.1.0')), DisplayString('SunOS zeus.snmplabs.com 4.1.3_U1 1 sun4m')), ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.2.0')), ObjectIdentifier('1.3.6.1.4.1.424242.1.1')]])
+    (0, 0, [[ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.1.0')), DisplayString('SunOS zeus.snmplabs.com 4.1.3_U1 1 sun4m'))], [ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.2.0')), ObjectIdentifier('1.3.6.1.4.1.424242.1.1'))]])
     >>>
 
     """

--- a/pysnmp/hlapi/twisted/cmdgen.py
+++ b/pysnmp/hlapi/twisted/cmdgen.py
@@ -453,13 +453,30 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
 
     * errorStatus (str) : True value indicates SNMP PDU error.
     * errorIndex (int) : Non-zero value refers to `varBinds[errorIndex-1]`
-    * varBinds (tuple) :
-        A sequence of sequences (e.g. 2-D array) of
-        :py:class:`~pysnmp.smi.rfc1902.ObjectType` class instances
-        representing a table of MIB variables returned in SNMP response.
-        Inner sequences represent table rows and ordered exactly the same
-        as `varBinds` in request. Number of rows might be less or equal
-        to `maxRepetitions` value in request.
+    * varBindTable (tuple):
+      A sequence of sequences (e.g. 2-D array) of
+      :py:class:`~pysnmp.smi.rfc1902.ObjectType` class instances representing a
+      table of MIB variables returned in SNMP response, with up to
+      ``maxRepetitions`` rows, i.e. ``len(varBindTable) <= maxRepetitions``.
+
+      For ``0 <= i < len(varBindTable)`` and ``0 <= j < len(varBinds)``,
+      ``varBindTable[i][j]`` represents:
+
+      - For non-repeaters (``j < nonRepeaters``), the first lexicographic
+        successor of ``varBinds[j]``, regardless the value of ``i``, or an
+        :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
+        :py:obj:`pysnmp.proto.rfc1905.endOfMibView` value if no such successor
+        exists;
+      - For repeaters (``j >= nonRepeaters``), the ``i``-th lexicographic
+        successor of ``varBinds[j]``, or an
+        :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
+        :py:obj:`pysnmp.proto.rfc1905.endOfMibView` value if no such successor
+        exists.
+
+      See :rfc:`3416#section-4.2.3` for details on the underlying
+      `GetBulkRequest-PDU` and the associated `GetResponse-PDU`, such as
+      specific conditions under which the server may truncate the response,
+      causing ``varBindTable`` to have less than ``maxRepetitions`` rows.
 
     User `error` callback is called with `errorIndication` object wrapped
     in :class:`~twisted.python.failure.Failure` object.

--- a/pysnmp/hlapi/twisted/cmdgen.py
+++ b/pysnmp/hlapi/twisted/cmdgen.py
@@ -465,12 +465,12 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
       - For non-repeaters (``j < nonRepeaters``), the first lexicographic
         successor of ``varBinds[j]``, regardless the value of ``i``, or an
         :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
-        :py:obj:`pysnmp.proto.rfc1905.endOfMibView` value if no such successor
+        :py:obj:`~pysnmp.proto.rfc1905.endOfMibView` value if no such successor
         exists;
       - For repeaters (``j >= nonRepeaters``), the ``i``-th lexicographic
         successor of ``varBinds[j]``, or an
         :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
-        :py:obj:`pysnmp.proto.rfc1905.endOfMibView` value if no such successor
+        :py:obj:`~pysnmp.proto.rfc1905.endOfMibView` value if no such successor
         exists.
 
       See :rfc:`3416#section-4.2.3` for details on the underlying

--- a/pysnmp/hlapi/twisted/cmdgen.py
+++ b/pysnmp/hlapi/twisted/cmdgen.py
@@ -474,7 +474,7 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
         exists.
 
       See :rfc:`3416#section-4.2.3` for details on the underlying
-      `GetBulkRequest-PDU` and the associated `GetResponse-PDU`, such as
+      ``GetBulkRequest-PDU`` and the associated ``GetResponse-PDU``, such as
       specific conditions under which the server may truncate the response,
       causing ``varBindTable`` to have less than ``maxRepetitions`` rows.
 


### PR DESCRIPTION
* Rename `varBinds` returned by `bulkCmd()` to `varBindTable` so as to better reflect the two-dimensional nature.
* Expand on the wording of `varBindTable`.
* Fix a misleading usage example.

Previous documentation along with the wrong usage example misled untrained readers (such as myself, not familiar with the column-oriented table structure returned by `GetBulkRequest`) to believe that the returned two-dimensional table was row-oriented, i.e. 1) `varBindTable` would have `len(varBind)` sub-sequences, one for each requested variable binding, and 2) each sub-sequence would have all the successors of the corresponding variable binding requested.