### PR TITLE
Do not cache indices with a mutable index value

### DIFF
--- a/pysnmp/smi/mibs/SNMPv2-SMI.py
+++ b/pysnmp/smi/mibs/SNMPv2-SMI.py
@@ -1230,8 +1230,12 @@ class MibTableRow(MibTree):
 
     def getInstIdFromIndices(self, *indices):
         """Return column instance identification from indices"""
-        if indices in self.__idxToIdCache:
+        try:
             return self.__idxToIdCache[indices]
+        except TypeError:
+            cacheable = False
+        except KeyError:
+            cacheable = True
         idx = 0
         instId = ()
         parentIndices = []
@@ -1243,7 +1247,8 @@ class MibTableRow(MibTree):
             instId += self.getAsName(syntax, impliedFlag, parentIndices)
             parentIndices.append(syntax)
             idx += 1
-        self.__idxToIdCache[indices] = instId
+        if cacheable:
+            self.__idxToIdCache[indices] = instId
         return instId
 
     # Table access by index


### PR DESCRIPTION
`NetworkAddress` is one such index value.

Without this, converting instance indices with a `NetworkAddress` value groks with `TypeError` because the value is not hashable and thus cannot be used as a key to `dict`.