### PR TITLE
Fix InetAddress-to-InetAddressIPv{4,6} index cast

### DIFF
--- a/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
+++ b/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
@@ -90,7 +90,6 @@ class InetAddress(TextualConvention, OctetString):
         for parentIndex in reversed(parentIndices):
             if isinstance(parentIndex, InetAddressType):
                 try:
-                    # TODO: newer pyasn1 should ensure .prettyPrint() returns unicode
                     return parentRow.getAsName(self.typeMap[parentIndex].clone(self.asOctets()), impliedFlag, parentIndices)
                 except KeyError:
                     pass

--- a/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
+++ b/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
@@ -91,8 +91,7 @@ class InetAddress(TextualConvention, OctetString):
             if isinstance(parentIndex, InetAddressType):
                 try:
                     # TODO: newer pyasn1 should ensure .prettyPrint() returns unicode
-                    prettyValue = self.asOctets().decode()
-                    return parentRow.getAsName(self.typeMap[parentIndex].clone(prettyValue), impliedFlag, parentIndices)
+                    return parentRow.getAsName(self.typeMap[parentIndex].clone(self._value), impliedFlag, parentIndices)
                 except KeyError:
                     pass
 

--- a/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
+++ b/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
@@ -91,7 +91,7 @@ class InetAddress(TextualConvention, OctetString):
             if isinstance(parentIndex, InetAddressType):
                 try:
                     # TODO: newer pyasn1 should ensure .prettyPrint() returns unicode
-                    return parentRow.getAsName(self.typeMap[parentIndex].clone(self._value), impliedFlag, parentIndices)
+                    return parentRow.getAsName(self.typeMap[parentIndex].clone(self.asOctets()), impliedFlag, parentIndices)
                 except KeyError:
                     pass
 


### PR DESCRIPTION
Previously, the pretty value of the `InetAddress` instance was being used.
Since `InetAddress` does not know how to format the raw octets to
protocol-specific syntax (IPv4 or IPv6), the pretty value was something
like `u'\x00\x00\x00\x00'` instead of `u'0.0.0.0'`, which in turn caused
parse error in the protocol-specific subclass.

Passing the raw value (4- or 16-byte octet string) itself works as the
protocol-specific subclasses know how to handle these.
