### PR TITLE
Migrate references from SourceForge

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,9 @@
 
+Revision 4.4.3, released 2017-12-XX
+-----------------------------------
+
+- Migrated references from SourceForge
+
 Revision 4.4.2, released 2017-11-11
 -----------------------------------
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SNMP library for Python
 [![GitHub license](https://img.shields.io/badge/license-BSD-blue.svg)](https://raw.githubusercontent.com/etingof/pysnmp/master/LICENSE.txt)
 
 This is a pure-Python, open source and free implementation of v1/v2c/v3
-SNMP engine distributed under 2-clause [BSD license](http://pysnmp.sourceforge.net/license.html).
+SNMP engine distributed under 2-clause [BSD license](http://snmplabs.com/pysnmp/license.html).
 
 The PySNMP project was initially sponsored by a [PSF](http://www.python.org/psf/) grant.
 Thank you!
@@ -24,7 +24,7 @@ Features
 * Asynchronous socket-based IO API support
 * [Twisted](http://twistedmatrix.com), [Asyncio](https://docs.python.org/3/library/asyncio.html)
   and [Trollius](http://trollius.readthedocs.org/index.html) integration
-* [PySMI](http://pysmi.sf.net) integration for dynamic MIB compilation
+* [PySMI](http://snmplabs.com/pysmi/) integration for dynamic MIB compilation
 * Built-in instrumentation exposing protocol engine operations
 * Python eggs and py2exe friendly
 * 100% Python, works with Python 2.4 though 3.6
@@ -55,9 +55,9 @@ $ pip install pysnmp
     
 to download and install PySNMP along with its dependencies:
 
-* [PyASN1](http://pyasn1.sf.net)
+* [PyASN1](http://snmplabs.com/pyasn1/)
 * [PyCryptodomex](https://pycryptodome.readthedocs.io) (required only if SNMPv3 encryption is in use)
-* [PySMI](http://pysmi.sf.net) (required for MIB services only)
+* [PySMI](http://snmplabs.com/pysmi/) (required for MIB services only)
 
 Besides the library, command-line [SNMP utilities](https://github.com/etingof/pysnmp-apps)
 written in pure-Python could be installed via:
@@ -123,7 +123,7 @@ if errorIndication:
 ```
 
 We maintain publicly available SNMP Agent and TRAP sink at 
-[demo.snmplabs.com](http://snmpsim.sourceforge.net/public-snmp-simulator.html). You are
+[demo.snmplabs.com](http://snmplabs.com/snmpsim/public-snmp-agent-simulator.html). You are
 welcome to use it while experimenting with whatever SNMP software you deal with.
 
 ```bash
@@ -140,19 +140,19 @@ Other than that, PySNMP is capable to automatically fetch and use required MIBs 
 or local directories. You could configure any MIB source available to you (including
 [this one](http://mibs.snmplabs.com/asn1/)) for that purpose.
 
-For more example scripts please refer to [examples section](http://pysnmp.sourceforge.net/examples/contents.html#high-level-snmp)
+For more example scripts please refer to [examples section](http://snmplabs.com/pysnmp/examples/contents.html#high-level-snmp)
 at pysnmp web site.
 
 Documentation
 -------------
 
-Library documentation and examples can be found at the [pysnmp project site](http://pysnmp.sf.net/).
+Library documentation and examples can be found at the [pysnmp project site](http://snmplabs.com/pysnmp/).
 
 If something does not work as expected, please
 [open an issue](https://github.com/etingof/pysnmp/issues) at GitHub or
 post your question [on Stack Overflow](http://stackoverflow.com/questions/ask)
 or try browsing pysnmp 
-[mailing list archives](https://sourceforge.net/p/pyasn1/mailman/pysnmp-users/).
+[mailing list archives](https://sourceforge.net/p/pysnmp/mailman/pysnmp-users/).
 
 Bug reports and PRs are appreciated! ;-)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -312,7 +312,8 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.4/', None),
-    'pysmi': ('http://pysmi.sf.net/', None),
+    'pyasn1': ('http://snmplabs.com/pyasn1/', None),
+    'pysmi': ('http://snmplabs.com/pysmi/', None),
     'twisted': ('https://twistedmatrix.com/documents/15.4.0/api/', None)
 }
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -21,7 +21,7 @@ PySNMP library
    be to write another MIB parser and code generator which would produce
    PySNMP compliant Python code right from MIB text files all by itself.
 
-   **Done:** see `PySMI project <http://pysmi.sf.net>`_ in conjuction with the latest PySNMP codebase.
+   **Done:** see `PySMI project <http://snmplabs.com/pysmi/>`_ in conjuction with the latest PySNMP codebase.
 
 #. Reverse MIB index. The variable-bindings received by the system whilst 
    in Manager role could be post-processed using the information kept in 
@@ -63,7 +63,7 @@ Stand-alone PySNMP-based tools
    include extensive configuration facilities, fine-graned access 
    control and logging.
 
-   **Done:** see `SNMP Proxy Forwarder <http://snmpfwd.sf.net>`_.
+   **Done:** see `SNMP Proxy Forwarder <http://snmplabs.com/snmpfwd/>`_.
 
 #. SNMP Trap Receiver. We see this application as a simple yet flexible 
    SNMP TRAP collector. It would listen on network sockets of different 
@@ -81,10 +81,10 @@ Stand-alone PySNMP-based tools
    a relational database application. So we are planning to put some more 
    efforts into the Simulator project as time permits. 
 
-   **Done:** since `snmpsim-0.2.4 <http://snmpsim.sf.net>`_ 
+   **Done:** since `snmpsim-0.2.4 <http://snmplabs.com/snmpsim/>`_ 
 
 If you need some particular feature - please, 
-`drop us a note <http://pysnmp.sourceforge.net/contact.html>`_ . Once we 
+`open a feature request <https://github.com/etingof/pysnmp/issues/new>`_ . Once we 
 see a greater demand in particular area, we would re-arrange our 
 development resources to meet it sooner. 
 
@@ -95,5 +95,5 @@ Contributions to the PySNMP source code is greatly appreciated as well.
 We require contributed code to run with Python 2.4 through the latest 
 Python version (which is 3.6 at the time of this writing). Contributed
 code will be redistributed under the terms of the same 
-`license <http://pysnmp.sourceforge.net/license.html>`_ as PySNMP is.
+`license <http://snmplabs.com/pysnmp/>`_ as PySNMP is.
 

--- a/docs/source/docs/api-reference.rst
+++ b/docs/source/docs/api-reference.rst
@@ -329,7 +329,7 @@ states in form of values. Those values each belong to one
 of SNMP types (:RFC:`1902#section-2`) which, in turn, are based
 on `ASN.1 <https://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One>`_ 
 data description language. PySNMP types are derived from
-`Python ASN.1 types <http://pyasn1.sf.net>`_ implementation.
+`Python ASN.1 types <http://snmplabs.com/pyasn1/>`_ implementation.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/docs/pysnmp-hlapi-tutorial.rst
+++ b/docs/source/docs/pysnmp-hlapi-tutorial.rst
@@ -100,7 +100,7 @@ Setting transport and target
 
 PySNMP supports UDP-over-IPv4 and UDP-over-IPv6 network transports.
 In this example we will query 
-`public SNMP Simulator <http://snmpsim.sourceforge.net/public-snmp-simulator.html>`_
+`public SNMP Simulator <http://snmplabs.com/snmpsim/public-snmp-simulator.html>`_
 available over IPv4 on the Internet at *demo.snmplabs.com*. Transport
 configuration is passed to SNMP LCD in form of properly initialized
 :py:class:`~pysnmp.hlapi.UdpTransportTarget` or

--- a/docs/source/docs/snmp-design.rst
+++ b/docs/source/docs/snmp-design.rst
@@ -98,7 +98,7 @@ SNMP-specific subtypes of those base ASN.1 types are:
 In addition to these scalar types, SNMP defines a way to collect them
 into ordered arrays. From these arrays 2-d tables could be built.
 
-PySNMP relies on the `PyASN1 <http://pyasn1.sf.net/>`_ package for
+PySNMP relies on the `PyASN1 <http://snmplabs.com/pyasn1/>`_ package for
 modeling all SNMP types.  With PyASN1, instances of ASN.1 types are
 represented by Python objects that look like either a string or an
 integer. 
@@ -229,7 +229,7 @@ managing entities.
 
 MIB convertion is performed automatically by PySNMP, but technically,
 it is handled by PySNMP sister project called
-`PySMI <http://pysmi.sf.net>`_. However you can also perform said
+`PySMI <http://snmplabs.com/pysmi/>`_. However you can also perform said
 conversion by hand with PySMI's *mibdump.py* tool.
 
 Protocol operations

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -5,9 +5,10 @@ Download PySNMP
    :maxdepth: 2
 
 The PySNMP software is provided under terms and conditions of BSD-style 
-license, and can be freely downloaded from Source Forge
-`download servers <http://sourceforge.net/projects/pysnmp/files/>`_ or 
-`PyPI <http://pypi.python.org/pypi/pysnmp/>`_. 
+license, and can be freely downloaded from 
+`PyPI <http://pypi.python.org/pypi/pysnmp/>`_ or
+GitHub (`master branch <https://github.com/etingof/pysnmp/archive/master.zip>`_).
+
 
 Besides official releases, it's advisable to try the cutting-edge
 development code that could be taken from PySNMP
@@ -66,6 +67,6 @@ The installation procedure for all the above packages is as follows
    # cd .. 
    # rm -rf package-X.X.X
 
-In case of any issues, please `let us know <http://pysnmp.sourceforge.net/contact.html>`_ so we could try to help out.
+In case of any issues, please open a `GitHub issue <https://github.com/etingof/pysnmp/issues/new>`_ so we could try to help out.
 
 

--- a/docs/source/examples/contents.rst
+++ b/docs/source/examples/contents.rst
@@ -136,7 +136,7 @@ easy_install: ::
 
 There's a public, multilingual SNMP Command Responder and Notification
 Receiver configured at
-`demo.snmplabs.com <http://snmpsim.sourceforge.net/public-snmp-simulator.html>`_ to let you run PySNMP examples scripts in a cut&paste fashion. If you
+`demo.snmplabs.com <http://snmplabs.com/snmpsim/public-snmp-simulator.html>`_ to let you run PySNMP examples scripts in a cut&paste fashion. If you
 wish to use your own SNMP Agent with these scripts, make sure to either
 configure your local snmpd and/or snmptrapd or use a valid address and
 SNMP credentials of your SNMP Agent in the examples to let them work.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -4,7 +4,7 @@ FAQ
 
 Here we have an ever-growing list of frequently asked questions regarding
 PySNMP usage issues. If you got an issue that you think is worth noting
-here, please `drop us a note <http://pysnmp.sourceforge.net/contact.html>`_.
+here, please open a `GitHub issue <https://github.com/etingof/pysnmp/issues>`_.
 
 Keep in mind that some the answers below may not be universally applicable
 to any PySNMP revision.

--- a/docs/source/faq/non-printable-snmp-values-apps.rst
+++ b/docs/source/faq/non-printable-snmp-values-apps.rst
@@ -35,6 +35,6 @@ A. Always use prettyPrint() method for all pyasn1-based objects -- it
     > > > rfc1902.IpAddress.prettyPrint(a)
     '1.2.3.4'
 
-See `pyasn1 tutorial <http://pyasn1.sourceforge.net/>`_ for more information
+See `pyasn1 docs <http://snmplabs.com/pyasn1/>`_ for more information
 on pyasn1 data model.
 

--- a/docs/source/faq/non-printable-snmp-values-tools.rst
+++ b/docs/source/faq/non-printable-snmp-values-tools.rst
@@ -1,4 +1,4 @@
-  
+
 Garbaged SNMP values (tools)
 ----------------------------
 

--- a/docs/source/faq/pass-custom-mib-to-manager.rst
+++ b/docs/source/faq/pass-custom-mib-to-manager.rst
@@ -6,7 +6,7 @@ Q. How to make use of random MIBs at my Manager application?
 
 A. Starting from PySNMP 4.3.x, plain-text (ASN.1) MIBs can be
    automatically parsed into PySNMP form by the
-   `PySMI <http://pysmi.sf.net>`_ tool.  PySNMP will call PySMI
+   `PySMI <http://snmplabs.com/pysmi/>`_ tool.  PySNMP will call PySMI
    automatically, parsed PySNMP MIB will be cached in
    $HOME/.pysnmp/mibs/ (default location).
 
@@ -24,6 +24,6 @@ A. Starting from PySNMP 4.3.x, plain-text (ASN.1) MIBs can be
 :download:`Download</../../examples/hlapi/asyncore/sync/manager/cmdgen/custom-asn1-mib-search-path.py>` script.
 
 Alternatively, you can invoke the
-`mibdump.py <http://pysmi.sourceforge.net/user-perspective.html>`_
+`mibdump.py <http://snmplabs.com/pysmi/mibdump.html>`_
 (shipped with PySMI) by hand and this way compile plain-text MIB
 into PySNMP format.

--- a/docs/source/oldsite.rst
+++ b/docs/source/oldsite.rst
@@ -4,7 +4,7 @@ Old site archive
 
 Starting from PySNMP 4.3.0, we redesigned all documentation and web-site.
 For previous versions of those please follow these links for
-`old examples <http://pysnmp.sf.net/examples/current/index.html>`_
+`old examples <http://snmplabs.com/pysnmp/examples/current/index.html>`_
 and
-`old documentation <http://pysnmp.sf.net/docs/current/index.html>`_
+`old documentation <http://snmplabs.com/pysnmp/docs/current/index.html>`_
 .

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -16,7 +16,7 @@ Fetch SNMP variable
 So just cut&paste the following code right into your Python prompt. The 
 code will performs SNMP GET operation for a sysDescr.0 object at a 
 publically available SNMP Command Responder at
-`demo.snmplabs.com <http://snmpsim.sourceforge.net/public-snmp-simulator.html>`_:
+`demo.snmplabs.com <http://snmplabs.com/snmpsim/public-snmp-simulator.html>`_:
 
 .. literalinclude:: /../../examples/hlapi/asyncore/sync/manager/cmdgen/v1-get.py
    :start-after: """#
@@ -38,7 +38,7 @@ Send SNMP TRAP
 --------------
 
 To send a trivial TRAP message to our hosted Notification Receiver at
-`demo.snmplabs.com <http://snmpsim.sourceforge.net/public-snmp-simulator.html>`_
+`demo.snmplabs.com <http://snmplabs.com/snmpsim/public-snmp-simulator.html>`_
 , just cut&paste the following code into your interactive Python session:
 
 .. literalinclude:: /../../examples/hlapi/asyncore/sync/agent/ntforg/default-v1-trap.py

--- a/pysnmp/__init__.py
+++ b/pysnmp/__init__.py
@@ -1,5 +1,5 @@
 # http://www.python.org/dev/peps/pep-0396/
-__version__ = '4.4.2'
+__version__ = '4.4.3'
 # backward compatibility
 version = tuple([int(x) for x in __version__.split('.')])
 majorVersionId = version[0]

--- a/pysnmp/cache.py
+++ b/pysnmp/cache.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # Limited-size dictionary-like class to use for caches
 #

--- a/pysnmp/carrier/asyncio/base.py
+++ b/pysnmp/carrier/asyncio/base.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # Copyright (C) 2014, Zebra Technologies
 # Authors: Matt Hooks <me@matthooks.com>

--- a/pysnmp/carrier/asyncio/dgram/base.py
+++ b/pysnmp/carrier/asyncio/dgram/base.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # Copyright (C) 2014, Zebra Technologies
 # Authors: Matt Hooks <me@matthooks.com>

--- a/pysnmp/carrier/asyncio/dgram/udp.py
+++ b/pysnmp/carrier/asyncio/dgram/udp.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # Copyright (C) 2014, Zebra Technologies
 # Authors: Matt Hooks <me@matthooks.com>

--- a/pysnmp/carrier/asyncio/dgram/udp6.py
+++ b/pysnmp/carrier/asyncio/dgram/udp6.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import socket
 from pysnmp.carrier.base import AbstractTransportAddress

--- a/pysnmp/carrier/asyncio/dispatch.py
+++ b/pysnmp/carrier/asyncio/dispatch.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # Copyright (C) 2014, Zebra Technologies
 # Authors: Matt Hooks <me@matthooks.com>

--- a/pysnmp/carrier/asyncore/base.py
+++ b/pysnmp/carrier/asyncore/base.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import socket
 import sys

--- a/pysnmp/carrier/asyncore/dgram/base.py
+++ b/pysnmp/carrier/asyncore/dgram/base.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import socket
 import errno

--- a/pysnmp/carrier/asyncore/dgram/udp.py
+++ b/pysnmp/carrier/asyncore/dgram/udp.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from socket import AF_INET
 from pysnmp.carrier.base import AbstractTransportAddress

--- a/pysnmp/carrier/asyncore/dgram/udp6.py
+++ b/pysnmp/carrier/asyncore/dgram/udp6.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.carrier import sockfix
 from pysnmp.carrier.base import AbstractTransportAddress

--- a/pysnmp/carrier/asyncore/dgram/unix.py
+++ b/pysnmp/carrier/asyncore/dgram/unix.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import os
 import random

--- a/pysnmp/carrier/asyncore/dispatch.py
+++ b/pysnmp/carrier/asyncore/dispatch.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from time import time
 from sys import exc_info

--- a/pysnmp/carrier/asynsock/dgram/udp.py
+++ b/pysnmp/carrier/asynsock/dgram/udp.py
@@ -2,6 +2,6 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.carrier.asyncore.dgram.udp import *

--- a/pysnmp/carrier/asynsock/dgram/udp6.py
+++ b/pysnmp/carrier/asynsock/dgram/udp6.py
@@ -2,6 +2,6 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.carrier.asyncore.dgram.udp6 import *

--- a/pysnmp/carrier/asynsock/dgram/unix.py
+++ b/pysnmp/carrier/asynsock/dgram/unix.py
@@ -2,6 +2,6 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.carrier.asyncore.dgram.unix import *

--- a/pysnmp/carrier/asynsock/dispatch.py
+++ b/pysnmp/carrier/asynsock/dispatch.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.carrier.asyncore.dispatch import *
 

--- a/pysnmp/carrier/base.py
+++ b/pysnmp/carrier/base.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.carrier import error
 

--- a/pysnmp/carrier/error.py
+++ b/pysnmp/carrier/error.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp import error
 

--- a/pysnmp/carrier/sockfix.py
+++ b/pysnmp/carrier/sockfix.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import socket
 

--- a/pysnmp/carrier/sockmsg.py
+++ b/pysnmp/carrier/sockmsg.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # The following routines act like sendto()/recvfrom() calls but additionally
 # support local address retrieval (what can be useful when listening on

--- a/pysnmp/carrier/twisted/base.py
+++ b/pysnmp/carrier/twisted/base.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # Copyright (C) 2008 Truelite Srl <info@truelite.it>
 # Author: Filippo Giunchedi <filippo@truelite.it>

--- a/pysnmp/carrier/twisted/dgram/base.py
+++ b/pysnmp/carrier/twisted/dgram/base.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from twisted.internet.protocol import DatagramProtocol

--- a/pysnmp/carrier/twisted/dgram/udp.py
+++ b/pysnmp/carrier/twisted/dgram/udp.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from twisted.internet import reactor

--- a/pysnmp/carrier/twisted/dgram/unix.py
+++ b/pysnmp/carrier/twisted/dgram/unix.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from twisted.internet import reactor

--- a/pysnmp/carrier/twisted/dispatch.py
+++ b/pysnmp/carrier/twisted/dispatch.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # Copyright (C) 2008 Truelite Srl <info@truelite.it>
 # Author: Filippo Giunchedi <filippo@truelite.it>

--- a/pysnmp/debug.py
+++ b/pysnmp/debug.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import logging
 from pyasn1.compat.octets import octs2ints

--- a/pysnmp/entity/config.py
+++ b/pysnmp/entity/config.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.compat.octets import null
 from pysnmp.carrier.asyncore.dgram import udp, udp6, unix

--- a/pysnmp/entity/engine.py
+++ b/pysnmp/entity/engine.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import os
 import shutil

--- a/pysnmp/entity/observer.py
+++ b/pysnmp/entity/observer.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp import error
 

--- a/pysnmp/entity/rfc3413/cmdgen.py
+++ b/pysnmp/entity/rfc3413/cmdgen.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from pysnmp.entity.rfc3413 import config

--- a/pysnmp/entity/rfc3413/cmdrsp.py
+++ b/pysnmp/entity/rfc3413/cmdrsp.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from pysnmp.proto import rfc1902, rfc1905, rfc3411, errind, error

--- a/pysnmp/entity/rfc3413/config.py
+++ b/pysnmp/entity/rfc3413/config.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.smi.error import SmiError, NoSuchInstanceError
 from pysnmp.entity import config

--- a/pysnmp/entity/rfc3413/context.py
+++ b/pysnmp/entity/rfc3413/context.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.type import univ
 from pyasn1.compat.octets import null

--- a/pysnmp/entity/rfc3413/mibvar.py
+++ b/pysnmp/entity/rfc3413/mibvar.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # THESE FUNCTIONS ARE OBSOLETE AND MUST NOT BE USED!
 # USE pysnmp.entity.rfc3413.oneliner.mibvar INSTEAD

--- a/pysnmp/entity/rfc3413/ntforg.py
+++ b/pysnmp/entity/rfc3413/ntforg.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from pyasn1.compat.octets import null

--- a/pysnmp/entity/rfc3413/ntfrcv.py
+++ b/pysnmp/entity/rfc3413/ntfrcv.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from pyasn1.compat.octets import null

--- a/pysnmp/entity/rfc3413/oneliner/cmdgen.py
+++ b/pysnmp/entity/rfc3413/oneliner/cmdgen.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # All code in this file belongs to obsolete, compatibility wrappers.
 # Never use interfaces below for new applications!

--- a/pysnmp/entity/rfc3413/oneliner/ntforg.py
+++ b/pysnmp/entity/rfc3413/oneliner/ntforg.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # All code in this file belongs to obsolete, compatibility wrappers.
 # Never use interfaces below for new applications!

--- a/pysnmp/error.py
+++ b/pysnmp/error.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 
 

--- a/pysnmp/hlapi/__init__.py
+++ b/pysnmp/hlapi/__init__.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.rfc1902 import *
 from pysnmp.proto.rfc1905 import NoSuchInstance, NoSuchObject, EndOfMibView

--- a/pysnmp/hlapi/asyncio/__init__.py
+++ b/pysnmp/hlapi/asyncio/__init__.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.rfc1902 import *
 from pysnmp.smi.rfc1902 import *

--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # Copyright (C) 2014, Zebra Technologies
 # Authors: Matt Hooks <me@matthooks.com>

--- a/pysnmp/hlapi/asyncio/ntforg.py
+++ b/pysnmp/hlapi/asyncio/ntforg.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # Copyright (C) 2014, Zebra Technologies
 # Authors: Matt Hooks <me@matthooks.com>

--- a/pysnmp/hlapi/asyncio/transport.py
+++ b/pysnmp/hlapi/asyncio/transport.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import socket
 import sys

--- a/pysnmp/hlapi/asyncore/__init__.py
+++ b/pysnmp/hlapi/asyncore/__init__.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.rfc1902 import *
 from pysnmp.smi.rfc1902 import *

--- a/pysnmp/hlapi/asyncore/cmdgen.py
+++ b/pysnmp/hlapi/asyncore/cmdgen.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.entity.rfc3413 import cmdgen
 from pysnmp.smi.rfc1902 import *

--- a/pysnmp/hlapi/asyncore/ntforg.py
+++ b/pysnmp/hlapi/asyncore/ntforg.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.smi.rfc1902 import *
 from pysnmp.entity.rfc3413 import ntforg

--- a/pysnmp/hlapi/asyncore/sync/__init__.py
+++ b/pysnmp/hlapi/asyncore/sync/__init__.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.rfc1902 import *
 from pysnmp.smi.rfc1902 import *

--- a/pysnmp/hlapi/asyncore/sync/cmdgen.py
+++ b/pysnmp/hlapi/asyncore/sync/cmdgen.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from sys import version_info
 from pysnmp.hlapi.asyncore import cmdgen

--- a/pysnmp/hlapi/asyncore/sync/compat/cmdgen.py
+++ b/pysnmp/hlapi/asyncore/sync/compat/cmdgen.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # This is a Python 2.6- version of the same file at level up
 #

--- a/pysnmp/hlapi/asyncore/sync/compat/ntforg.py
+++ b/pysnmp/hlapi/asyncore/sync/compat/ntforg.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 # This is a Python 2.6- version of the same file at level up
 #

--- a/pysnmp/hlapi/asyncore/sync/ntforg.py
+++ b/pysnmp/hlapi/asyncore/sync/ntforg.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from sys import version_info
 from pysnmp.hlapi.asyncore import ntforg

--- a/pysnmp/hlapi/asyncore/transport.py
+++ b/pysnmp/hlapi/asyncore/transport.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import socket
 import sys

--- a/pysnmp/hlapi/auth.py
+++ b/pysnmp/hlapi/auth.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.entity import config
 from pysnmp import error

--- a/pysnmp/hlapi/context.py
+++ b/pysnmp/hlapi/context.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.compat.octets import null
 

--- a/pysnmp/hlapi/lcd.py
+++ b/pysnmp/hlapi/lcd.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.entity import config
 from pysnmp import nextid, error

--- a/pysnmp/hlapi/transport.py
+++ b/pysnmp/hlapi/transport.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.compat.octets import null
 from pysnmp.carrier.base import AbstractTransport

--- a/pysnmp/hlapi/twisted/cmdgen.py
+++ b/pysnmp/hlapi/twisted/cmdgen.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.smi.rfc1902 import *
 from pysnmp.hlapi.auth import *

--- a/pysnmp/hlapi/twisted/ntforg.py
+++ b/pysnmp/hlapi/twisted/ntforg.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.smi.rfc1902 import *
 from pysnmp.hlapi.auth import *

--- a/pysnmp/hlapi/twisted/transport.py
+++ b/pysnmp/hlapi/twisted/transport.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import socket, sys
 from pysnmp.carrier.twisted.dgram import udp

--- a/pysnmp/hlapi/varbinds.py
+++ b/pysnmp/hlapi/varbinds.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.smi import view
 from pysnmp.smi.rfc1902 import *

--- a/pysnmp/nextid.py
+++ b/pysnmp/nextid.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import random
 

--- a/pysnmp/proto/acmod/rfc3415.py
+++ b/pysnmp/proto/acmod/rfc3415.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.smi.error import NoSuchInstanceError
 from pysnmp.proto import errind, error

--- a/pysnmp/proto/acmod/void.py
+++ b/pysnmp/proto/acmod/void.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto import errind, error
 from pysnmp import debug

--- a/pysnmp/proto/api/__init__.py
+++ b/pysnmp/proto/api/__init__.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.api import v1, v2c, verdec
 

--- a/pysnmp/proto/api/v1.py
+++ b/pysnmp/proto/api/v1.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.type import univ
 from pysnmp.proto import rfc1155, rfc1157, error

--- a/pysnmp/proto/api/v2c.py
+++ b/pysnmp/proto/api/v2c.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto import rfc1901, rfc1902, rfc1905
 from pysnmp.proto.api import v1

--- a/pysnmp/proto/api/verdec.py
+++ b/pysnmp/proto/api/verdec.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.type import univ
 from pyasn1.codec.ber import decoder, eoo

--- a/pysnmp/proto/cache.py
+++ b/pysnmp/proto/cache.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto import error
 

--- a/pysnmp/proto/errind.py
+++ b/pysnmp/proto/errind.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 
 

--- a/pysnmp/proto/error.py
+++ b/pysnmp/proto/error.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.error import PyAsn1Error
 from pysnmp.error import PySnmpError

--- a/pysnmp/proto/mpmod/base.py
+++ b/pysnmp/proto/mpmod/base.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.mpmod import cache
 from pysnmp.proto import error

--- a/pysnmp/proto/mpmod/cache.py
+++ b/pysnmp/proto/mpmod/cache.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto import error
 from pysnmp import nextid

--- a/pysnmp/proto/mpmod/rfc2576.py
+++ b/pysnmp/proto/mpmod/rfc2576.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from pyasn1.codec.ber import decoder, eoo

--- a/pysnmp/proto/mpmod/rfc3412.py
+++ b/pysnmp/proto/mpmod/rfc3412.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2016, Ilya Etingof <ilya@glas.net>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from pysnmp.proto.mpmod.base import AbstractMessageProcessingModel

--- a/pysnmp/proto/proxy/rfc2576.py
+++ b/pysnmp/proto/proxy/rfc2576.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto import rfc1905, rfc3411, error
 from pysnmp.proto.api import v1, v2c

--- a/pysnmp/proto/rfc1155.py
+++ b/pysnmp/proto/rfc1155.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.type import univ, tag, constraint, namedtype
 from pyasn1.error import PyAsn1Error

--- a/pysnmp/proto/rfc1157.py
+++ b/pysnmp/proto/rfc1157.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.type import univ, tag, namedtype, namedval
 from pysnmp.proto import rfc1155

--- a/pysnmp/proto/rfc1901.py
+++ b/pysnmp/proto/rfc1901.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.type import univ, namedtype, namedval
 from pysnmp.proto import rfc1905

--- a/pysnmp/proto/rfc1902.py
+++ b/pysnmp/proto/rfc1902.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from sys import version_info
 from pyasn1.type import univ, tag, constraint, namedtype, namedval

--- a/pysnmp/proto/rfc1905.py
+++ b/pysnmp/proto/rfc1905.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.type import univ, tag, constraint, namedtype, namedval
 from pysnmp.proto import rfc1902

--- a/pysnmp/proto/rfc3411.py
+++ b/pysnmp/proto/rfc3411.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto import rfc1157, rfc1905
 

--- a/pysnmp/proto/rfc3412.py
+++ b/pysnmp/proto/rfc3412.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from pyasn1.compat.octets import null

--- a/pysnmp/proto/secmod/base.py
+++ b/pysnmp/proto/secmod/base.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.secmod import cache
 from pysnmp.proto import error

--- a/pysnmp/proto/secmod/cache.py
+++ b/pysnmp/proto/secmod/cache.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp import nextid
 from pysnmp.proto import error

--- a/pysnmp/proto/secmod/eso/priv/aes192.py
+++ b/pysnmp/proto/secmod/eso/priv/aes192.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.secmod.eso.priv import aesbase
 

--- a/pysnmp/proto/secmod/eso/priv/aes256.py
+++ b/pysnmp/proto/secmod/eso/priv/aes256.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.secmod.eso.priv import aesbase
 

--- a/pysnmp/proto/secmod/eso/priv/aesbase.py
+++ b/pysnmp/proto/secmod/eso/priv/aesbase.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.secmod.rfc3826.priv import aes
 from pysnmp.proto.secmod.rfc3414.auth import hmacmd5, hmacsha

--- a/pysnmp/proto/secmod/eso/priv/des3.py
+++ b/pysnmp/proto/secmod/eso/priv/des3.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import random
 from pysnmp.proto.secmod.rfc3414.priv import base

--- a/pysnmp/proto/secmod/rfc2576.py
+++ b/pysnmp/proto/secmod/rfc2576.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from pyasn1.codec.ber import encoder

--- a/pysnmp/proto/secmod/rfc3414/__init__.py
+++ b/pysnmp/proto/secmod/rfc3414/__init__.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.secmod.rfc3414 import service
 

--- a/pysnmp/proto/secmod/rfc3414/auth/base.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/base.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto import errind, error
 

--- a/pysnmp/proto/secmod/rfc3414/auth/hmacmd5.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/hmacmd5.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 try:
     from hashlib import md5

--- a/pysnmp/proto/secmod/rfc3414/auth/hmacsha.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/hmacsha.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 try:
     from hashlib import sha1

--- a/pysnmp/proto/secmod/rfc3414/auth/noauth.py
+++ b/pysnmp/proto/secmod/rfc3414/auth/noauth.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.secmod.rfc3414.auth import base
 from pysnmp.proto import errind, error

--- a/pysnmp/proto/secmod/rfc3414/localkey.py
+++ b/pysnmp/proto/secmod/rfc3414/localkey.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 try:
     from hashlib import md5, sha1

--- a/pysnmp/proto/secmod/rfc3414/priv/base.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/base.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto import error
 

--- a/pysnmp/proto/secmod/rfc3414/priv/des.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/des.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import random
 from pysnmp.proto.secmod.rfc3414.priv import base

--- a/pysnmp/proto/secmod/rfc3414/priv/nopriv.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/nopriv.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto.secmod.rfc3414.priv import base
 from pysnmp.proto import errind, error

--- a/pysnmp/proto/secmod/rfc3414/service.py
+++ b/pysnmp/proto/secmod/rfc3414/service.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import time
 import sys

--- a/pysnmp/proto/secmod/rfc3826/priv/aes.py
+++ b/pysnmp/proto/secmod/rfc3826/priv/aes.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import random
 from pyasn1.type import univ

--- a/pysnmp/proto/secmod/rfc7860/auth/hmacsha2.py
+++ b/pysnmp/proto/secmod/rfc7860/auth/hmacsha2.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Olivier Verriest <verri@x25.pm>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 import hmac

--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import os
 import sys

--- a/pysnmp/smi/compiler.py
+++ b/pysnmp/smi/compiler.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import os
 import sys

--- a/pysnmp/smi/error.py
+++ b/pysnmp/smi/error.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.error import PyAsn1Error
 from pysnmp.error import PySnmpError

--- a/pysnmp/smi/exval.py
+++ b/pysnmp/smi/exval.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pysnmp.proto import rfc1905
 

--- a/pysnmp/smi/indices.py
+++ b/pysnmp/smi/indices.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from bisect import bisect
 

--- a/pysnmp/smi/instrum.py
+++ b/pysnmp/smi/instrum.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 import traceback

--- a/pysnmp/smi/mibs/ASN1-ENUMERATION.py
+++ b/pysnmp/smi/mibs/ASN1-ENUMERATION.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.type import namedval
 

--- a/pysnmp/smi/mibs/ASN1-REFINEMENT.py
+++ b/pysnmp/smi/mibs/ASN1-REFINEMENT.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.type import constraint
 

--- a/pysnmp/smi/mibs/ASN1.py
+++ b/pysnmp/smi/mibs/ASN1.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from pyasn1.type import univ
 from pysnmp.proto import rfc1902

--- a/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
+++ b/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module INET-ADDRESS-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module INET-ADDRESS-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/INET-ADDRESS-MIB
 # Produced by pysmi-0.1.2 at Sat Apr 15 23:36:33 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/PYSNMP-MIB.py
+++ b/pysnmp/smi/mibs/PYSNMP-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module PYSNMP-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module PYSNMP-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/PYSNMP-MIB
 # Produced by pysmi-0.1.3 at Mon Apr 17 11:46:02 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/PYSNMP-SOURCE-MIB.py
+++ b/pysnmp/smi/mibs/PYSNMP-SOURCE-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module PYSNMP-SOURCE-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module PYSNMP-SOURCE-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/PYSNMP-SOURCE-MIB
 # Produced by pysmi-0.1.3 at Mon Apr 17 11:46:02 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/PYSNMP-USM-MIB.py
+++ b/pysnmp/smi/mibs/PYSNMP-USM-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module PYSNMP-USM-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module PYSNMP-USM-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/PYSNMP-USM-MIB
 # Produced by pysmi-0.1.3 at Mon Apr 17 11:46:02 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/RFC1158-MIB.py
+++ b/pysnmp/smi/mibs/RFC1158-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module RFC1158-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module RFC1158-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/RFC1158-MIB
 # Produced by pysmi-0.1.3 at Mon Apr 17 12:12:07 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/RFC1213-MIB.py
+++ b/pysnmp/smi/mibs/RFC1213-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module RFC1213-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module RFC1213-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/RFC1213-MIB
 # Produced by pysmi-0.1.3 at Mon Apr 17 12:12:07 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMP-COMMUNITY-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-COMMUNITY-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module SNMP-COMMUNITY-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module SNMP-COMMUNITY-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMP-COMMUNITY-MIB
 # Produced by pysmi-0.1.3 at Mon Apr 17 13:47:39 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMP-FRAMEWORK-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-FRAMEWORK-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module SNMP-FRAMEWORK-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module SNMP-FRAMEWORK-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMP-FRAMEWORK-MIB
 # Produced by pysmi-0.1.3 at Mon Apr 17 13:59:41 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMP-MPD-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-MPD-MIB.py
@@ -2,10 +2,10 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 #
-# PySNMP MIB module SNMP-MPD-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module SNMP-MPD-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMP-MPD-MIB
 # Produced by pysmi-0.1.3 at Tue Apr 18 00:17:00 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMP-NOTIFICATION-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-NOTIFICATION-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module SNMP-NOTIFICATION-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module SNMP-NOTIFICATION-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMP-NOTIFICATION-MIB
 # Produced by pysmi-0.1.3 at Tue Apr 18 00:41:37 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMP-PROXY-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-PROXY-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module SNMP-PROXY-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module SNMP-PROXY-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMP-PROXY-MIB
 # Produced by pysmi-0.1.3 at Tue Apr 18 00:43:17 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMP-TARGET-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-TARGET-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module SNMP-TARGET-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module SNMP-TARGET-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMP-TARGET-MIB
 # Produced by pysmi-0.1.3 at Tue Apr 18 00:44:13 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMP-USER-BASED-SM-3DES-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-USER-BASED-SM-3DES-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module SNMP-USER-BASED-SM-3DES-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module SNMP-USER-BASED-SM-3DES-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMP-USER-BASED-SM-3DES-MIB
 # Produced by pysmi-0.1.3 at Tue Apr 18 00:47:21 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMP-USER-BASED-SM-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-USER-BASED-SM-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module SNMP-USER-BASED-SM-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module SNMP-USER-BASED-SM-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMP-USER-BASED-SM-MIB
 # Produced by pysmi-0.1.3 at Tue Apr 18 00:48:12 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMP-USM-AES-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-USM-AES-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module SNMP-USM-AES-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module SNMP-USM-AES-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMP-USM-AES-MIB
 # Produced by pysmi-0.1.3 at Tue Apr 18 00:49:58 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMP-USM-HMAC-SHA2-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-USM-HMAC-SHA2-MIB.py
@@ -1,5 +1,5 @@
 #
-# PySNMP MIB module SNMP-USM-HMAC-SHA2-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module SNMP-USM-HMAC-SHA2-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMP-USM-HMAC-SHA2-MIB
 # Produced by pysmi-0.1.4 at Thu Aug  3 02:14:32 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMP-VIEW-BASED-ACM-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-VIEW-BASED-ACM-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module SNMP-VIEW-BASED-ACM-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module SNMP-VIEW-BASED-ACM-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMP-VIEW-BASED-ACM-MIB
 # Produced by pysmi-0.1.3 at Tue Apr 18 00:50:37 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMPv2-CONF.py
+++ b/pysnmp/smi/mibs/SNMPv2-CONF.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module SNMPv2-CONF (http://pysnmp.sf.net)
+# PySNMP MIB module SNMPv2-CONF (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMPv2-CONF
 # Produced by pysmi-0.1.3 at Tue Apr 18 00:51:39 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMPv2-MIB.py
+++ b/pysnmp/smi/mibs/SNMPv2-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module SNMPv2-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module SNMPv2-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMPv2-MIB
 # Produced by pysmi-0.1.3 at Tue Apr 18 00:52:45 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/SNMPv2-SMI.py
+++ b/pysnmp/smi/mibs/SNMPv2-SMI.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 import traceback

--- a/pysnmp/smi/mibs/SNMPv2-TC.py
+++ b/pysnmp/smi/mibs/SNMPv2-TC.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 import inspect

--- a/pysnmp/smi/mibs/SNMPv2-TM.py
+++ b/pysnmp/smi/mibs/SNMPv2-TM.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module SNMPv2-TM (http://pysnmp.sf.net)
+# PySNMP MIB module SNMPv2-TM (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/SNMPv2-TM
 # Produced by pysmi-0.1.3 at Tue Apr 18 01:01:19 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/TRANSPORT-ADDRESS-MIB.py
+++ b/pysnmp/smi/mibs/TRANSPORT-ADDRESS-MIB.py
@@ -2,9 +2,9 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
-# PySNMP MIB module TRANSPORT-ADDRESS-MIB (http://pysnmp.sf.net)
+# PySNMP MIB module TRANSPORT-ADDRESS-MIB (http://snmplabs.com/pysnmp)
 # ASN.1 source http://mibs.snmplabs.com:80/asn1/TRANSPORT-ADDRESS-MIB
 # Produced by pysmi-0.1.3 at Tue Apr 18 01:08:18 2017
 # On host grommit.local platform Darwin version 16.4.0 by user ilya

--- a/pysnmp/smi/mibs/instances/__PYSNMP-USM-MIB.py
+++ b/pysnmp/smi/mibs/instances/__PYSNMP-USM-MIB.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 MibScalarInstance, = mibBuilder.importSymbols('SNMPv2-SMI', 'MibScalarInstance')
 

--- a/pysnmp/smi/mibs/instances/__SNMP-FRAMEWORK-MIB.py
+++ b/pysnmp/smi/mibs/instances/__SNMP-FRAMEWORK-MIB.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import time
 

--- a/pysnmp/smi/mibs/instances/__SNMP-MPD-MIB.py
+++ b/pysnmp/smi/mibs/instances/__SNMP-MPD-MIB.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 MibScalarInstance, = mibBuilder.importSymbols('SNMPv2-SMI', 'MibScalarInstance')
 

--- a/pysnmp/smi/mibs/instances/__SNMP-TARGET-MIB.py
+++ b/pysnmp/smi/mibs/instances/__SNMP-TARGET-MIB.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 MibScalarInstance, = mibBuilder.importSymbols(
     'SNMPv2-SMI',

--- a/pysnmp/smi/mibs/instances/__SNMP-USER-BASED-SM-MIB.py
+++ b/pysnmp/smi/mibs/instances/__SNMP-USER-BASED-SM-MIB.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 MibScalarInstance, = mibBuilder.importSymbols('SNMPv2-SMI', 'MibScalarInstance')
 

--- a/pysnmp/smi/mibs/instances/__SNMP-VIEW-BASED-ACM-MIB.py
+++ b/pysnmp/smi/mibs/instances/__SNMP-VIEW-BASED-ACM-MIB.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 MibScalarInstance, = mibBuilder.importSymbols('SNMPv2-SMI', 'MibScalarInstance')
 

--- a/pysnmp/smi/mibs/instances/__SNMPv2-MIB.py
+++ b/pysnmp/smi/mibs/instances/__SNMPv2-MIB.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 from sys import version
 from time import time

--- a/pysnmp/smi/rfc1902.py
+++ b/pysnmp/smi/rfc1902.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from pysnmp.proto import rfc1902, rfc1905
@@ -257,7 +257,7 @@ class ObjectIdentity(object):
         Normally, ASN.1-to-Python MIB modules conversion is performed
         automatically through PySNMP/PySMI interaction. ASN1 MIB modules
         could also be manually compiled into Python via the
-        `mibdump.py <http://pysmi.sourceforge.net/user-perspective.html>`_
+        `mibdump.py <http://snmplabs.com/pysmi/mibdump.html>`_
         tool.
 
         Examples
@@ -768,7 +768,7 @@ class ObjectType(object):
         Normally, ASN.1-to-Python MIB modules conversion is performed
         automatically through PySNMP/PySMI interaction. ASN1 MIB modules
         could also be manually compiled into Python via the
-        `mibdump.py <http://pysmi.sourceforge.net/user-perspective.html>`_
+        `mibdump.py <http://snmplabs.com/pysmi/mibdump.html>`_
         tool.
 
         Examples
@@ -1058,7 +1058,7 @@ class NotificationType(object):
         Normally, ASN.1-to-Python MIB modules conversion is performed
         automatically through PySNMP/PySMI interaction. ASN1 MIB modules
         could also be manually compiled into Python via the
-        `mibdump.py <http://pysmi.sourceforge.net/user-perspective.html>`_
+        `mibdump.py <http://snmplabs.com/pysmi/mibdump.html>`_
         tool.
 
         Examples

--- a/pysnmp/smi/view.py
+++ b/pysnmp/smi/view.py
@@ -2,7 +2,7 @@
 # This file is part of pysnmp software.
 #
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
-# License: http://pysnmp.sf.net/license.html
+# License: http://snmplabs.com/pysnmp/license.html
 #
 import sys
 from pysnmp.smi.indices import OrderedDict, OidOrderedDict


### PR DESCRIPTION
This PR replaces all references to SourceForge services mostly to `snmplabs.com`.