### PR TITLE
Move to a hybrid crypto backend, using pyca/cryptography when available but failing back to PyCryptodomex for Python versions that pyca/cryptography does not support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ docs/source/.templates/layout.html
 
 # Virtual envs
 venv*
+
+# Tox
+.tox/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ venv*
 
 # Tox
 .tox/
+
+# Pyenv
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - pip install -e .
   - pip install pysnmp-mibs
 script:
-  - sh runtests.sh
+  - travis_wait 20 sh runtests.sh

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,10 @@
 
+Revision 4.?.?, released 2018-??-??
+-----------------------------------
+
+- Crypto abstraction layer added to allow use of pyca/cryptography instead of Pycryptodome
+- Dependencies modified to use pyca/cryptography for supported Python versions
+
 Revision 4.4.4, released 2018-01-03
 -----------------------------------
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ $ pip install pysnmp
 to download and install PySNMP along with its dependencies:
 
 * [PyASN1](http://snmplabs.com/pyasn1/)
-* [PyCryptodomex](https://pycryptodome.readthedocs.io) (required only if SNMPv3 encryption is in use)
 * [PySMI](http://snmplabs.com/pysmi/) (required for MIB services only)
+* A supported cryptography backend (required only if SNMPv3 encryption is in use)
+    * [pyca/cryptography](http://cryptography.io/) for Python 2.7 and 3.4+
+    * [PyCryptodomex](https://pycryptodome.readthedocs.io) for Python 2.4-2.6 and 3.2-3.3
 
 Besides the library, command-line [SNMP utilities](https://github.com/etingof/pysnmp-apps)
 written in pure-Python could be installed via:

--- a/pysnmp/crypto/__init__.py
+++ b/pysnmp/crypto/__init__.py
@@ -1,9 +1,15 @@
-"""Backend-independent cryptographic implementations to allow migration to pyca/cryptography
+"""Backend-selecting cryptographic logic to allow migration to pyca/cryptography
 without immediately dropping support for legacy minor Python versions.
+
+On installation, the correct backend dependency is selected based on the Python
+version. Versions that are supported by pyca/cryptography use that backend; all
+other versions (currently 2.4, 2.5, 2.6, 3.2, and 3.3) fall back to Pycryptodome.
 """
 from pysnmp.proto import errind, error
 CRYPTOGRPAHY = 'cryptography'
 CRYPTODOME = 'Cryptodome'
+
+# Determine the available backend. Always prefer cryptography if it is available.
 try:
     import cryptography
     backend = CRYPTOGRPAHY
@@ -15,53 +21,111 @@ except ImportError:
         backend = None
 
 
-def raise_backend_error(*args, **kwargs):
-    raise error.StatusInformation(
-        errorIndication=errind.decryptionError
-    )
-
-
 def _cryptodome_encrypt(cipher_factory, plaintext, key, iv):
-    """"""
+    """Use a Pycryptodome cipher factory to encrypt data.
+
+    :param cipher_factory: Factory callable that builds a Pycryptodome Cipher instance based
+    on the key and IV
+    :type cipher_factory: callable
+    :param bytes plaintext: Plaintext data to encrypt
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: Encrypted ciphertext
+    :rtype: bytes
+    """
     encryptor = cipher_factory(key, iv)
     return encryptor.encrypt(plaintext)
 
 
 def _cryptodome_decrypt(cipher_factory, ciphertext, key, iv):
-    """"""
+    """Use a Pycryptodome cipher factory to decrypt data.
+
+    :param cipher_factory: Factory callable that builds a Pycryptodome Cipher instance based
+    on the key and IV
+    :type cipher_factory: callable
+    :param bytes ciphertext: Ciphertext data to decrypt
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: Decrypted plaintext
+    :rtype: bytes
+    """
     decryptor = cipher_factory(key, iv)
     return decryptor.decrypt(ciphertext)
 
 
 def _cryptography_encrypt(cipher_factory, plaintext, key, iv):
-    """"""
+    """Use a cryptography cipher factory to encrypt data.
+
+    :param cipher_factory: Factory callable that builds a cryptography Cipher instance based
+    on the key and IV
+    :type cipher_factory: callable
+    :param bytes plaintext: Plaintext data to encrypt
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: Encrypted ciphertext
+    :rtype: bytes
+    """
     encryptor = cipher_factory(key, iv).encryptor()
     return encryptor.update(plaintext) + encryptor.finalize()
 
 
 def _cryptography_decrypt(cipher_factory, ciphertext, key, iv):
-    """"""
+    """Use a cryptography cipher factory to decrypt data.
+
+    :param cipher_factory: Factory callable that builds a cryptography Cipher instance based
+    on the key and IV
+    :type cipher_factory: callable
+    :param bytes ciphertext: Ciphertext data to decrypt
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: Decrypted plaintext
+    :rtype: bytes
+    """
     decryptor = cipher_factory(key, iv).decryptor()
     return decryptor.update(ciphertext) + decryptor.finalize()
 
 
 _DECRYPT_MAP = {
     CRYPTOGRPAHY: _cryptography_decrypt,
-    CRYPTODOME: _cryptodome_decrypt,
-    None: raise_backend_error
+    CRYPTODOME: _cryptodome_decrypt
 }
 _ENCRYPT_MAP = {
     CRYPTOGRPAHY: _cryptography_encrypt,
-    CRYPTODOME: _cryptodome_encrypt,
-    None: raise_backend_error
+    CRYPTODOME: _cryptodome_encrypt
 }
 
 
 def generic_encrypt(cipher_factory_map, plaintext, key, iv):
-    """"""
+    """Encrypt data using the available backend.
+
+    :param dict cipher_factory_map: Dictionary that maps the backend name to a cipher factory
+    callable for that backend
+    :param bytes plaintext: Plaintext data to encrypt
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: Encrypted ciphertext
+    :rtype: bytes
+    """
+    if backend is None:
+        raise error.StatusInformation(
+            errorIndication=errind.encryptionError
+        )
     return _ENCRYPT_MAP[backend](cipher_factory_map[backend], plaintext, key, iv)
 
 
-def generic_decrypt(cipher_factory_map, plaintext, key, iv):
-    """"""
-    return _DECRYPT_MAP[backend](cipher_factory_map[backend], plaintext, key, iv)
+def generic_decrypt(cipher_factory_map, ciphertext, key, iv):
+    """Decrypt data using the available backend.
+
+    :param dict cipher_factory_map: Dictionary that maps the backend name to a cipher factory
+    callable for that backend
+    :param bytes ciphertext: Ciphertext data to decrypt
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: Decrypted plaintext
+    :rtype: bytes
+    """
+    if backend is None:
+        raise error.StatusInformation(
+            errorIndication=errind.decryptionError
+        )
+    return _DECRYPT_MAP[backend](cipher_factory_map[backend], ciphertext, key, iv)

--- a/pysnmp/crypto/__init__.py
+++ b/pysnmp/crypto/__init__.py
@@ -6,13 +6,13 @@ version. Versions that are supported by pyca/cryptography use that backend; all
 other versions (currently 2.4, 2.5, 2.6, 3.2, and 3.3) fall back to Pycryptodome.
 """
 from pysnmp.proto import errind, error
-CRYPTOGRPAHY = 'cryptography'
+CRYPTOGRAPHY = 'cryptography'
 CRYPTODOME = 'Cryptodome'
 
 # Determine the available backend. Always prefer cryptography if it is available.
 try:
     import cryptography
-    backend = CRYPTOGRPAHY
+    backend = CRYPTOGRAPHY
 except ImportError:
     try:
         import Cryptodome
@@ -86,11 +86,11 @@ def _cryptography_decrypt(cipher_factory, ciphertext, key, iv):
 
 
 _DECRYPT_MAP = {
-    CRYPTOGRPAHY: _cryptography_decrypt,
+    CRYPTOGRAPHY: _cryptography_decrypt,
     CRYPTODOME: _cryptodome_decrypt
 }
 _ENCRYPT_MAP = {
-    CRYPTOGRPAHY: _cryptography_encrypt,
+    CRYPTOGRAPHY: _cryptography_encrypt,
     CRYPTODOME: _cryptodome_encrypt
 }
 

--- a/pysnmp/crypto/__init__.py
+++ b/pysnmp/crypto/__init__.py
@@ -1,0 +1,67 @@
+"""Backend-independent cryptographic implementations to allow migration to pyca/cryptography
+without immediately dropping support for legacy minor Python versions.
+"""
+from pysnmp.proto import errind, error
+CRYPTOGRPAHY = 'cryptography'
+CRYPTODOME = 'Cryptodome'
+try:
+    import cryptography
+    backend = CRYPTOGRPAHY
+except ImportError:
+    try:
+        import Cryptodome
+        backend = CRYPTODOME
+    except ImportError:
+        backend = None
+
+
+def raise_backend_error(*args, **kwargs):
+    raise error.StatusInformation(
+        errorIndication=errind.decryptionError
+    )
+
+
+def _cryptodome_encrypt(cipher_factory, plaintext, key, iv):
+    """"""
+    encryptor = cipher_factory(key, iv)
+    return encryptor.encrypt(plaintext)
+
+
+def _cryptodome_decrypt(cipher_factory, ciphertext, key, iv):
+    """"""
+    decryptor = cipher_factory(key, iv)
+    return decryptor.decrypt(ciphertext)
+
+
+def _cryptography_encrypt(cipher_factory, plaintext, key, iv):
+    """"""
+    encryptor = cipher_factory(key, iv).encryptor()
+    return encryptor.update(plaintext) + encryptor.finalize()
+
+
+def _cryptography_decrypt(cipher_factory, ciphertext, key, iv):
+    """"""
+    decryptor = cipher_factory(key, iv).decryptor()
+    return decryptor.update(ciphertext) + decryptor.finalize()
+
+
+_DECRYPT_MAP = {
+    CRYPTOGRPAHY: _cryptography_decrypt,
+    CRYPTODOME: _cryptodome_decrypt,
+    None: raise_backend_error
+}
+_ENCRYPT_MAP = {
+    CRYPTOGRPAHY: _cryptography_encrypt,
+    CRYPTODOME: _cryptodome_encrypt,
+    None: raise_backend_error
+}
+
+
+def generic_encrypt(cipher_factory_map, plaintext, key, iv):
+    """"""
+    return _ENCRYPT_MAP[backend](cipher_factory_map[backend], plaintext, key, iv)
+
+
+def generic_decrypt(cipher_factory_map, plaintext, key, iv):
+    """"""
+    return _DECRYPT_MAP[backend](cipher_factory_map[backend], plaintext, key, iv)

--- a/pysnmp/crypto/aes.py
+++ b/pysnmp/crypto/aes.py
@@ -3,9 +3,9 @@ Crypto logic for RFC3826.
 
 https://tools.ietf.org/html/rfc3826
 """
-from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRPAHY, generic_decrypt, generic_encrypt
+from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRAPHY, generic_decrypt, generic_encrypt
 
-if backend == CRYPTOGRPAHY:
+if backend == CRYPTOGRAPHY:
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
 elif backend == CRYPTODOME:
@@ -38,7 +38,7 @@ def _cryptography_cipher(key, iv):
 
 
 _CIPHER_FACTORY_MAP = {
-    CRYPTOGRPAHY: _cryptography_cipher,
+    CRYPTOGRAPHY: _cryptography_cipher,
     CRYPTODOME: _cryptodome_cipher
 }
 

--- a/pysnmp/crypto/aes.py
+++ b/pysnmp/crypto/aes.py
@@ -1,5 +1,9 @@
-""""""
-from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRPAHY, generic_decrypt, generic_encrypt, raise_backend_error
+"""
+Crypto logic for RFC3826.
+
+https://tools.ietf.org/html/rfc3826
+"""
+from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRPAHY, generic_decrypt, generic_encrypt
 
 if backend == CRYPTOGRPAHY:
     from cryptography.hazmat.backends import default_backend
@@ -9,12 +13,23 @@ elif backend == CRYPTODOME:
 
 
 def _cryptodome_cipher(key, iv):
-    """"""
+    """Build a Pycryptodome AES Cipher object.
+
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: DES3 Cipher instance
+    """
     return AES.new(key, AES.MODE_CFB, iv, segment_size=128)
 
 
 def _cryptography_cipher(key, iv):
-    """"""
+    """Build a cryptography AES Cipher object.
+
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: TripleDES Cipher instance
+    :rtype: cryptography.hazmat.primitives.ciphers.Cipher
+    """
     return Cipher(
         algorithm=algorithms.AES(key),
         mode=modes.CFB(iv),
@@ -24,16 +39,29 @@ def _cryptography_cipher(key, iv):
 
 _CIPHER_FACTORY_MAP = {
     CRYPTOGRPAHY: _cryptography_cipher,
-    CRYPTODOME: _cryptodome_cipher,
-    None: raise_backend_error
+    CRYPTODOME: _cryptodome_cipher
 }
 
 
 def encrypt(plaintext, key, iv):
-    """"""
+    """Encrypt data using AES on the available backend.
+
+    :param bytes plaintext: Plaintext data to encrypt
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: Encrypted ciphertext
+    :rtype: bytes
+    """
     return generic_encrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)
 
 
-def decrypt(plaintext, key, iv):
-    """"""
-    return generic_decrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)
+def decrypt(ciphertext, key, iv):
+    """Decrypt data using AES on the available backend.
+
+    :param bytes ciphertext: Ciphertext data to decrypt
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: Decrypted plaintext
+    :rtype: bytes
+    """
+    return generic_decrypt(_CIPHER_FACTORY_MAP, ciphertext, key, iv)

--- a/pysnmp/crypto/aes.py
+++ b/pysnmp/crypto/aes.py
@@ -17,7 +17,7 @@ def _cryptodome_cipher(key, iv):
 
     :param bytes key: Encryption key
     :param bytes IV: Initialization vector
-    :returns: DES3 Cipher instance
+    :returns: AES Cipher instance
     """
     return AES.new(key, AES.MODE_CFB, iv, segment_size=128)
 
@@ -27,7 +27,7 @@ def _cryptography_cipher(key, iv):
 
     :param bytes key: Encryption key
     :param bytes IV: Initialization vector
-    :returns: TripleDES Cipher instance
+    :returns: AES Cipher instance
     :rtype: cryptography.hazmat.primitives.ciphers.Cipher
     """
     return Cipher(

--- a/pysnmp/crypto/aes.py
+++ b/pysnmp/crypto/aes.py
@@ -1,0 +1,39 @@
+""""""
+from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRPAHY, generic_decrypt, generic_encrypt, raise_backend_error
+
+if backend == CRYPTOGRPAHY:
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
+elif backend == CRYPTODOME:
+    from Cryptodome.Cipher import AES
+
+
+def _cryptodome_cipher(key, iv):
+    """"""
+    return AES.new(key, AES.MODE_CFB, iv, segment_size=128)
+
+
+def _cryptography_cipher(key, iv):
+    """"""
+    return Cipher(
+        algorithm=algorithms.AES(key),
+        mode=modes.CFB(iv),
+        backend=default_backend()
+    )
+
+
+_CIPHER_FACTORY_MAP = {
+    CRYPTOGRPAHY: _cryptography_cipher,
+    CRYPTODOME: _cryptodome_cipher,
+    None: raise_backend_error
+}
+
+
+def encrypt(plaintext, key, iv):
+    """"""
+    return generic_encrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)
+
+
+def decrypt(plaintext, key, iv):
+    """"""
+    return generic_decrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)

--- a/pysnmp/crypto/des.py
+++ b/pysnmp/crypto/des.py
@@ -1,0 +1,30 @@
+""""""
+from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRPAHY, des3, generic_decrypt, generic_encrypt, raise_backend_error
+
+if backend == CRYPTODOME:
+    from Cryptodome.Cipher import DES
+
+
+def _cryptodome_cipher(key, iv):
+    """"""
+    return DES.new(key, DES.MODE_CBC, iv)
+
+
+_CIPHER_FACTORY_MAP = {
+    CRYPTODOME: _cryptodome_cipher,
+    None: raise_backend_error
+}
+
+
+def encrypt(plaintext, key, iv):
+    """"""
+    if backend == CRYPTOGRPAHY:
+        return des3.encrypt(plaintext, key * 3, iv)
+    return generic_encrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)
+
+
+def decrypt(plaintext, key, iv):
+    """"""
+    if backend == CRYPTOGRPAHY:
+        return des3.decrypt(plaintext, key * 3, iv)
+    return generic_decrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)

--- a/pysnmp/crypto/des.py
+++ b/pysnmp/crypto/des.py
@@ -3,7 +3,7 @@ Crypto logic for RFC3414.
 
 https://tools.ietf.org/html/rfc3414
 """
-from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRPAHY, des3, generic_decrypt, generic_encrypt
+from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRAPHY, des3, generic_decrypt, generic_encrypt
 
 if backend == CRYPTODOME:
     from Cryptodome.Cipher import DES
@@ -40,7 +40,7 @@ def encrypt(plaintext, key, iv):
     :returns: Encrypted ciphertext
     :rtype: bytes
     """
-    if backend == CRYPTOGRPAHY:
+    if backend == CRYPTOGRAPHY:
         return des3.encrypt(plaintext, key * 3, iv)
     return generic_encrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)
 
@@ -54,6 +54,6 @@ def decrypt(ciphertext, key, iv):
     :returns: Decrypted plaintext
     :rtype: bytes
     """
-    if backend == CRYPTOGRPAHY:
+    if backend == CRYPTOGRAPHY:
         return des3.decrypt(ciphertext, key * 3, iv)
     return generic_decrypt(_CIPHER_FACTORY_MAP, ciphertext, key, iv)

--- a/pysnmp/crypto/des.py
+++ b/pysnmp/crypto/des.py
@@ -1,30 +1,59 @@
-""""""
-from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRPAHY, des3, generic_decrypt, generic_encrypt, raise_backend_error
+"""
+Crypto logic for RFC3414.
+
+https://tools.ietf.org/html/rfc3414
+"""
+from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRPAHY, des3, generic_decrypt, generic_encrypt
 
 if backend == CRYPTODOME:
     from Cryptodome.Cipher import DES
 
 
 def _cryptodome_cipher(key, iv):
-    """"""
+    """Build a Pycryptodome DES Cipher object.
+
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: DES Cipher instance
+    """
     return DES.new(key, DES.MODE_CBC, iv)
 
 
 _CIPHER_FACTORY_MAP = {
-    CRYPTODOME: _cryptodome_cipher,
-    None: raise_backend_error
+    CRYPTODOME: _cryptodome_cipher
 }
+
+# Cryptography does not support DES directly because it is a seriously old, insecure,
+# and deprecated algorithm. However, triple DES is just three rounds of DES (encrypt,
+# decrypt, encrypt) done by taking a key three times the size of a DES key and breaking
+# it into three pieces. So triple DES with des_key * 3 is equivalent to DES.
+# Pycryptodome's triple DES implementation will actually throw an error if it receives
+# a key that reduces to DES.
 
 
 def encrypt(plaintext, key, iv):
-    """"""
+    """Encrypt data using DES on the available backend.
+
+    :param bytes plaintext: Plaintext data to encrypt
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: Encrypted ciphertext
+    :rtype: bytes
+    """
     if backend == CRYPTOGRPAHY:
         return des3.encrypt(plaintext, key * 3, iv)
     return generic_encrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)
 
 
-def decrypt(plaintext, key, iv):
-    """"""
+def decrypt(ciphertext, key, iv):
+    """Decrypt data using DES on the available backend.
+
+    :param bytes ciphertext: Ciphertext data to decrypt
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: Decrypted plaintext
+    :rtype: bytes
+    """
     if backend == CRYPTOGRPAHY:
-        return des3.decrypt(plaintext, key * 3, iv)
-    return generic_decrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)
+        return des3.decrypt(ciphertext, key * 3, iv)
+    return generic_decrypt(_CIPHER_FACTORY_MAP, ciphertext, key, iv)

--- a/pysnmp/crypto/des3.py
+++ b/pysnmp/crypto/des3.py
@@ -3,9 +3,9 @@ Crypto logic for Reeder 3DES-EDE for USM (Internet draft).
 
 https://tools.ietf.org/html/draft-reeder-snmpv3-usm-3desede-00
 """
-from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRPAHY, generic_decrypt, generic_encrypt
+from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRAPHY, generic_decrypt, generic_encrypt
 
-if backend == CRYPTOGRPAHY:
+if backend == CRYPTOGRAPHY:
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
 elif backend == CRYPTODOME:
@@ -38,7 +38,7 @@ def _cryptography_cipher(key, iv):
 
 
 _CIPHER_FACTORY_MAP = {
-    CRYPTOGRPAHY: _cryptography_cipher,
+    CRYPTOGRAPHY: _cryptography_cipher,
     CRYPTODOME: _cryptodome_cipher
 }
 

--- a/pysnmp/crypto/des3.py
+++ b/pysnmp/crypto/des3.py
@@ -1,5 +1,9 @@
-""""""
-from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRPAHY, generic_decrypt, generic_encrypt, raise_backend_error
+"""
+Crypto logic for Reeder 3DES-EDE for USM (Internet draft).
+
+https://tools.ietf.org/html/draft-reeder-snmpv3-usm-3desede-00
+"""
+from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRPAHY, generic_decrypt, generic_encrypt
 
 if backend == CRYPTOGRPAHY:
     from cryptography.hazmat.backends import default_backend
@@ -9,12 +13,23 @@ elif backend == CRYPTODOME:
 
 
 def _cryptodome_cipher(key, iv):
-    """"""
+    """Build a Pycryptodome DES3 Cipher object.
+
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: DES3 Cipher instance
+    """
     return DES3.new(key, DES3.MODE_CBC, iv)
 
 
 def _cryptography_cipher(key, iv):
-    """"""
+    """Build a cryptography TripleDES Cipher object.
+
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: TripleDES Cipher instance
+    :rtype: cryptography.hazmat.primitives.ciphers.Cipher
+    """
     return Cipher(
         algorithm=algorithms.TripleDES(key),
         mode=modes.CBC(iv),
@@ -24,16 +39,29 @@ def _cryptography_cipher(key, iv):
 
 _CIPHER_FACTORY_MAP = {
     CRYPTOGRPAHY: _cryptography_cipher,
-    CRYPTODOME: _cryptodome_cipher,
-    None: raise_backend_error
+    CRYPTODOME: _cryptodome_cipher
 }
 
 
 def encrypt(plaintext, key, iv):
-    """"""
+    """Encrypt data using triple DES on the available backend.
+
+    :param bytes plaintext: Plaintext data to encrypt
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: Encrypted ciphertext
+    :rtype: bytes
+    """
     return generic_encrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)
 
 
-def decrypt(plaintext, key, iv):
-    """"""
-    return generic_decrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)
+def decrypt(ciphertext, key, iv):
+    """Decrypt data using triple DES on the available backend.
+
+    :param bytes ciphertext: Ciphertext data to decrypt
+    :param bytes key: Encryption key
+    :param bytes IV: Initialization vector
+    :returns: Decrypted plaintext
+    :rtype: bytes
+    """
+    return generic_decrypt(_CIPHER_FACTORY_MAP, ciphertext, key, iv)

--- a/pysnmp/crypto/des3.py
+++ b/pysnmp/crypto/des3.py
@@ -1,0 +1,39 @@
+""""""
+from pysnmp.crypto import backend, CRYPTODOME, CRYPTOGRPAHY, generic_decrypt, generic_encrypt, raise_backend_error
+
+if backend == CRYPTOGRPAHY:
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
+elif backend == CRYPTODOME:
+    from Cryptodome.Cipher import DES3
+
+
+def _cryptodome_cipher(key, iv):
+    """"""
+    return DES3.new(key, DES3.MODE_CBC, iv)
+
+
+def _cryptography_cipher(key, iv):
+    """"""
+    return Cipher(
+        algorithm=algorithms.TripleDES(key),
+        mode=modes.CBC(iv),
+        backend=default_backend()
+    )
+
+
+_CIPHER_FACTORY_MAP = {
+    CRYPTOGRPAHY: _cryptography_cipher,
+    CRYPTODOME: _cryptodome_cipher,
+    None: raise_backend_error
+}
+
+
+def encrypt(plaintext, key, iv):
+    """"""
+    return generic_encrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)
+
+
+def decrypt(plaintext, key, iv):
+    """"""
+    return generic_decrypt(_CIPHER_FACTORY_MAP, plaintext, key, iv)

--- a/pysnmp/proto/secmod/eso/priv/des3.py
+++ b/pysnmp/proto/secmod/eso/priv/des3.py
@@ -5,7 +5,7 @@
 # License: http://snmplabs.com/pysnmp/license.html
 #
 import random
-from pysnmp.crypto.des3 import decrypt, encrypt
+from pysnmp.crypto import des3
 from pysnmp.proto.secmod.rfc3414.priv import base
 from pysnmp.proto.secmod.rfc3414.auth import hmacmd5, hmacsha
 from pysnmp.proto.secmod.rfc3414 import localkey
@@ -117,7 +117,7 @@ class Des3(base.AbstractEncryptionService):
         privParameters = univ.OctetString(salt)
 
         plaintext = dataToEncrypt + univ.OctetString((0,) * (8 - len(dataToEncrypt) % 8)).asOctets()
-        ciphertext = encrypt(plaintext, des3Key, iv)
+        ciphertext = des3.encrypt(plaintext, des3Key, iv)
 
         return univ.OctetString(ciphertext), privParameters
 
@@ -138,6 +138,6 @@ class Des3(base.AbstractEncryptionService):
             )
 
         ciphertext = encryptedData.asOctets()
-        plaintext = decrypt(ciphertext, des3Key, iv)
+        plaintext = des3.decrypt(ciphertext, des3Key, iv)
 
         return plaintext

--- a/pysnmp/proto/secmod/rfc3414/priv/des.py
+++ b/pysnmp/proto/secmod/rfc3414/priv/des.py
@@ -5,7 +5,7 @@
 # License: http://snmplabs.com/pysnmp/license.html
 #
 import random
-from pysnmp.crypto.des import decrypt, encrypt
+from pysnmp.crypto import des
 from pysnmp.proto.secmod.rfc3414.priv import base
 from pysnmp.proto.secmod.rfc3414.auth import hmacmd5, hmacsha
 from pysnmp.proto.secmod.rfc3414 import localkey
@@ -107,7 +107,7 @@ class Des(base.AbstractEncryptionService):
 
         # 8.1.1.2
         plaintext = dataToEncrypt + univ.OctetString((0,) * (8 - len(dataToEncrypt) % 8)).asOctets()
-        ciphertext = encrypt(plaintext, desKey, iv)
+        ciphertext = des.encrypt(plaintext, desKey, iv)
 
         # 8.3.1.3 & 4
         return univ.OctetString(ciphertext), privParameters
@@ -134,4 +134,4 @@ class Des(base.AbstractEncryptionService):
             )
 
         # 8.3.2.6
-        return decrypt(encryptedData.asOctets(), desKey, iv)
+        return des.decrypt(encryptedData.asOctets(), desKey, iv)

--- a/pysnmp/proto/secmod/rfc3826/priv/aes.py
+++ b/pysnmp/proto/secmod/rfc3826/priv/aes.py
@@ -6,7 +6,7 @@
 #
 import random
 from pyasn1.type import univ
-from pysnmp.crypto.aes import decrypt, encrypt
+from pysnmp.crypto import aes
 from pysnmp.proto.secmod.rfc3414.priv import base
 from pysnmp.proto.secmod.rfc3414.auth import hmacmd5, hmacsha
 from pysnmp.proto.secmod.rfc7860.auth import hmacsha2
@@ -110,7 +110,7 @@ class Aes(base.AbstractEncryptionService):
         # PyCrypto seems to require padding
         dataToEncrypt = dataToEncrypt + univ.OctetString((0,) * (16 - len(dataToEncrypt) % 16)).asOctets()
 
-        ciphertext = encrypt(dataToEncrypt, aesKey, iv)
+        ciphertext = aes.encrypt(dataToEncrypt, aesKey, iv)
 
         # 3.3.1.4
         return univ.OctetString(ciphertext), univ.OctetString(salt)
@@ -134,4 +134,4 @@ class Aes(base.AbstractEncryptionService):
         encryptedData = encryptedData + univ.OctetString((0,) * (16 - len(encryptedData) % 16)).asOctets()
 
         # 3.3.2.4-6
-        return decrypt(encryptedData.asOctets(), aesKey, iv)
+        return aes.decrypt(encryptedData.asOctets(), aesKey, iv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pycryptodomex; python_version == '3.2'
 pycryptodomex; python_version == '3.3'
 cryptography; python_version >= '3.4'
 pyasn1>=0.2.3
+ordereddict; python_version < '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 pysmi
-pycryptodomex
+pycryptodomex; python_version < '2.7'
+cryptography; python_version == '2.7'
+pycryptodomex; python_version == '3.2'
+pycryptodomex; python_version == '3.3'
+cryptography; python_version >= '3.4'
 pyasn1>=0.2.3

--- a/setup.py
+++ b/setup.py
@@ -50,11 +50,11 @@ def howto_install_setuptools():
 """)
 
 
-if sys.version_info[:2] < (2, 4):
+py_version = sys.version_info[:2]
+if py_version < (2, 4):
     print("ERROR: this package requires Python 2.4 or later!")
     sys.exit(1)
 
-py_version = sys.version_info[:2]
 if py_version < (2, 7) or (py_version >= (3, 0) and py_version < (3, 4)):
     crypto_lib = 'pycryptodomex'
 else:
@@ -77,7 +77,7 @@ except ImportError:
     from distutils.core import setup
 
     params = {}
-    if sys.version_info[:2] > (2, 4):
+    if py_version > (2, 4):
         params['requires'] = ['pyasn1(>=0.2.3)', 'pysmi', crypto_lib]
 
 doclines = [x.strip() for x in (__doc__ or '').split('\n') if x]

--- a/setup.py
+++ b/setup.py
@@ -54,11 +54,17 @@ if sys.version_info[:2] < (2, 4):
     print("ERROR: this package requires Python 2.4 or later!")
     sys.exit(1)
 
+py_version = sys.version_info[:2]
+if py_version < (2, 7) or (py_version >= (3, 0) and py_version < (3, 4)):
+    crypto_lib = 'pycryptodomex'
+else:
+    crypto_lib = 'cryptography'
+
 try:
     from setuptools import setup
 
     params = {
-        'install_requires': ['pyasn1>=0.2.3', 'pysmi', 'pycryptodomex'],
+        'install_requires': ['pyasn1>=0.2.3', 'pysmi', crypto_lib],
         'zip_safe': True
     }
 
@@ -72,7 +78,7 @@ except ImportError:
 
     params = {}
     if sys.version_info[:2] > (2, 4):
-        params['requires'] = ['pyasn1(>=0.2.3)', 'pysmi', 'pycryptodomex']
+        params['requires'] = ['pyasn1(>=0.2.3)', 'pysmi', crypto_lib]
 
 doclines = [x.strip() for x in (__doc__ or '').split('\n') if x]
 
@@ -101,6 +107,7 @@ params.update({
                  'pysnmp.carrier.twisted.dgram',
                  'pysnmp.carrier.asyncio',
                  'pysnmp.carrier.asyncio.dgram',
+                 'pysnmp.crypto',
                  'pysnmp.entity',
                  'pysnmp.entity.rfc3413',
                  'pysnmp.entity.rfc3413.oneliner',

--- a/setup.py
+++ b/setup.py
@@ -60,11 +60,16 @@ if py_version < (2, 7) or (py_version >= (3, 0) and py_version < (3, 4)):
 else:
     crypto_lib = 'cryptography'
 
+requires = ['pyasn1>=0.2.3', 'pysmi', crypto_lib]
+
+if py_version < (2, 7):
+    requires.append('ordereddict')
+
 try:
     from setuptools import setup
 
     params = {
-        'install_requires': ['pyasn1>=0.2.3', 'pysmi', crypto_lib],
+        'install_requires': requires,
         'zip_safe': True
     }
 
@@ -78,7 +83,7 @@ except ImportError:
 
     params = {}
     if py_version > (2, 4):
-        params['requires'] = ['pyasn1(>=0.2.3)', 'pysmi', crypto_lib]
+        params['requires'] = requires
 
 doclines = [x.strip() for x in (__doc__ or '').split('\n') if x]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[envlist]
+envlist = py{27,34,35,36}
+
+[testenv]
+commands = {toxinidir}/runtests.sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [envlist]
-envlist = py{26,27,34,35,36}
+envlist = py{26,27,33,34,35,36}
 
 [testenv]
 commands = {toxinidir}/runtests.sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [envlist]
-envlist = py{27,34,35,36}
+envlist = py{26,27,34,35,36}
 
 [testenv]
 commands = {toxinidir}/runtests.sh


### PR DESCRIPTION
Per #130, this consolidates crypto logic and moves to a hybrid crypto backend, using pyca/cryptography when available but failing back to PyCryptodomex for Python versions that pyca/cryptography does not support.

Also mixed in here are some fixes that consistently make the Python 2.6 tests run successfully (looks like you use `ordereddict` directly, but whether or not to bring in the backport was delegated to another dependency, and that didn't always work to actually bring in the backport: not the backport is brought in directly if needed) and adding a tox config to make local testing easier. I also bumped up the timeout for the Travis runs to 20 minutes from the default 10 minutes because I periodically had issues with the test suites taking a bit longer than 10 minutes and timing out Travis.