### PR TITLE
Migrate to new PyPI website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
 SNMP library for Python
 -----------------------
-[![PyPI](https://img.shields.io/pypi/v/pysnmp.svg?maxAge=2592000)](https://pypi.python.org/pypi/pysnmp)
-[![Python Versions](https://img.shields.io/pypi/pyversions/pysnmp.svg)](https://pypi.python.org/pypi/pysnmp/)
+[![PyPI](https://img.shields.io/pypi/v/pysnmp.svg?maxAge=2592000)](https://pypi.org/project/pysnmp/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/pysnmp.svg)](https://pypi.org/project/pysnmp/)
 [![Build status](https://travis-ci.org/etingof/pysnmp.svg?branch=master)](https://secure.travis-ci.org/etingof/pysnmp)
 [![GitHub license](https://img.shields.io/badge/license-BSD-blue.svg)](https://raw.githubusercontent.com/etingof/pysnmp/master/LICENSE.txt)
 
@@ -44,7 +44,7 @@ Features, specific to SNMPv3 model include:
 Download & Install
 ------------------
 
-The PySNMP software is freely available for download from [PyPI](https://pypi.python.org/pypi/pysnmp)
+The PySNMP software is freely available for download from [PyPI](https://pypi.org/project/pysnmp/)
 and [GitHub](https://github.com/etingof/pysnmp.git).
 
 Just run:

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -24,7 +24,7 @@ examples are written for the 4.4 and later versions in mind.
 Older materials are still available under the obsolete section.
 
 Besides the libraries, a set of pure-Python 
-`command-line tools <https://pypi.python.org/pypi/snmpclitools/>`_
+`command-line tools <https://pypi.org/project/snmpclitools/>`_
 are shipped along with the system. Those tools mimic the interface
 and behaviour of popular Net-SNMP snmpget/snmpset/snmpwalk utilities.
 They may be useful in a cross-platform situations as well as a testing

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -6,7 +6,7 @@ Download PySNMP
 
 The PySNMP software is provided under terms and conditions of BSD-style 
 license, and can be freely downloaded from 
-`PyPI <http://pypi.python.org/pypi/pysnmp/>`_ or
+`PyPI <https://pypi.org/project/pysnmp/>`_ or
 GitHub (`master branch <https://github.com/etingof/pysnmp/archive/master.zip>`_).
 
 
@@ -30,7 +30,7 @@ or
 
 In case you do not have the easy_install command on your system but still 
 would like to use the on-line package installation method, please install 
-`setuptools <http://pypi.python.org/pypi/setuptools>`_ package by 
+`setuptools <https://pypi.org/project/setuptools/>`_ package by 
 downloading and running `ez_setup.pz <https://bootstrap.pypa.io/ez_setup.py>`_ bootstrap:
 
 .. code-block:: bash
@@ -42,15 +42,15 @@ In case you are installing PySNMP on an off-line system, the following
 packages need to be downloaded and installed for PySNMP to become 
 operational:
 
-* `pysnmp <https://pypi.python.org/pypi/pysnmp/>`_,
+* `pysnmp <https://pypi.org/project/pysnmp/>`_,
   SNMP engine implementation
-* `pyasn1 <https://pypi.python.org/pypi/pyasn1>`_,
+* `pyasn1 <https://pypi.org/project/pyasn1/>`_,
   used for handling ASN.1 objects
-* `pysmi <https://pypi.python.org/pypi/pysmi/>`_ for automatic
+* `pysmi <https://pypi.org/project/pysmi/>`_ for automatic
   MIB download and compilation. That helps visualizing more SNMP objects
 
 Optional:
-* `pysnmpcrypto <https://pypi.python.org/pypi/pysnmpcrypto/>`_,
+* `pysnmpcrypto <https://pypi.org/project/pysnmpcrypto/>`_,
   for strong SNMPv3 crypto support
 
 The installation procedure for all the above packages is as follows 


### PR DESCRIPTION
According to [1], the PyPI website of pypi.python.org has changed
to https://pypi.org. This patch updates all references to the
legacy site.

[1] https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html

Signed-off-by: Eric Brown <browne@vmware.com>