### PR TITLE
Fixed zero boots time on trap

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
 Revision 4.4.5, released 2018-04-XX
 -----------------------------------
 
+- Fixed zero SNMPv3 boots/time values put in SNMPv3 TRAP messages
 - Fixed broken InetAddressType rendering caused by a pyasn1 regression
 - Fixed typo in RFC1158 module
 


### PR DESCRIPTION
This patch makes SNMPv3 message boots/time fields initialized from local SNMP engine values whenever TRAP/Response messages are being generated.

Before this fix zero boots/time values were put into SNMP TRAP message what goes against the specification and can cause funny behavior on the receiving side.