### PR TITLE
Remove `pysnmp.carrier.asynsock` sub-package

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,9 +10,13 @@ Revision 5.0.0, released 2018-07-??
   PyCryptodomex to pyca/cryptography whenever available on the
   platform.
 - Many really old backward-compatibility code snippets removed.
-  Most importantly, the `pysnmp.entity.rfc3413.oneliner` and
-  everything related to (non-standard) UNIX domain socket transport
-  are gone.
+  Most importantly:
+  
+  * `pysnmp.entity.rfc3413.oneliner` and everything related
+    to the (non-standard) UNIX domain socket transport is gone
+  * `pysnmp.carrier.asynsock` backward-compatible wrapper over
+    `pysnmp.carrier.asyncore` is gone
+
 - The MIB instrumentation API overhauled in backward incompatible
   way:
 

--- a/examples/v1arch/asyncore/agent/ntforg/send-inform-over-ipv4-and-ipv6.py
+++ b/examples/v1arch/asyncore/agent/ntforg/send-inform-over-ipv4-and-ipv6.py
@@ -18,8 +18,8 @@ The following Net-SNMP command will produce similar SNMP notification:
 
 """#
 from time import time
-from pysnmp.carrier.asynsock.dispatch import AsynsockDispatcher
-from pysnmp.carrier.asynsock.dgram import udp, udp6
+from pysnmp.carrier.asyncore.dispatch import AsyncoreDispatcher
+from pysnmp.carrier.asyncore.dgram import udp, udp6
 from pyasn1.codec.ber import encoder, decoder
 from pysnmp.proto.api import v2c as pMod
 
@@ -61,7 +61,7 @@ def cbRecvFun(transportDispatcher, transportDomain, transportAddress,
     return wholeMsg
 
 
-transportDispatcher = AsynsockDispatcher()
+transportDispatcher = AsyncoreDispatcher()
 
 transportDispatcher.registerRecvCbFun(cbRecvFun)
 transportDispatcher.registerTimerCbFun(cbTimerFun)

--- a/pysnmp/carrier/asynsock/__init__.py
+++ b/pysnmp/carrier/asynsock/__init__.py
@@ -1,1 +1,0 @@
-# This file is necessary to make this directory a package.

--- a/pysnmp/carrier/asynsock/dgram/__init__.py
+++ b/pysnmp/carrier/asynsock/dgram/__init__.py
@@ -1,1 +1,0 @@
-# This file is necessary to make this directory a package.

--- a/pysnmp/carrier/asynsock/dgram/udp.py
+++ b/pysnmp/carrier/asynsock/dgram/udp.py
@@ -1,7 +1,0 @@
-#
-# This file is part of pysnmp software.
-#
-# Copyright (c) 2005-2018, Ilya Etingof <etingof@gmail.com>
-# License: http://snmplabs.com/pysnmp/license.html
-#
-from pysnmp.carrier.asyncore.dgram.udp import *

--- a/pysnmp/carrier/asynsock/dgram/udp6.py
+++ b/pysnmp/carrier/asynsock/dgram/udp6.py
@@ -1,7 +1,0 @@
-#
-# This file is part of pysnmp software.
-#
-# Copyright (c) 2005-2018, Ilya Etingof <etingof@gmail.com>
-# License: http://snmplabs.com/pysnmp/license.html
-#
-from pysnmp.carrier.asyncore.dgram.udp6 import *

--- a/pysnmp/carrier/asynsock/dispatch.py
+++ b/pysnmp/carrier/asynsock/dispatch.py
@@ -1,9 +1,0 @@
-#
-# This file is part of pysnmp software.
-#
-# Copyright (c) 2005-2018, Ilya Etingof <etingof@gmail.com>
-# License: http://snmplabs.com/pysnmp/license.html
-#
-from pysnmp.carrier.asyncore.dispatch import *
-
-AsynsockDispatcher = AsyncoreDispatcher

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,6 @@ params.update({
                  'pysnmp.smi.mibs',
                  'pysnmp.smi.mibs.instances',
                  'pysnmp.carrier',
-                 'pysnmp.carrier.asynsock',
-                 'pysnmp.carrier.asynsock.dgram',
                  'pysnmp.carrier.asyncore',
                  'pysnmp.carrier.asyncore.dgram',
                  'pysnmp.carrier.twisted',


### PR DESCRIPTION
Legacy `pysnmp.carrier.asynsock` backward-compatible wrapper over `pysnmp.carrier.asyncore` is gone