### PR TITLE
Add PySnmpError.cause attribute

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
 Revision 4.4.5, released 2018-04-XX
 -----------------------------------
 
+- Added PySnmpError.cause attribute holding parent exception tuple
 - Fixed broken InetAddressType rendering caused by a pyasn1 regression
 - Fixed typo in RFC1158 module
 - Fixed possible infinite loop in GETBULK response PDU builder

--- a/pysnmp/error.py
+++ b/pysnmp/error.py
@@ -5,6 +5,10 @@
 # License: http://snmplabs.com/pysnmp/license.html
 #
 
+import sys
+
 
 class PySnmpError(Exception):
-    pass
+    def __init__(self, message):
+        self.cause = sys.exc_info()
+        Exception.__init__(self, '%s, caused by %s: %s' % (message, self.cause[0], self.cause[1]))


### PR DESCRIPTION
The `.cause` attribute would hold the same info as returned by the `exc_info()` at the moment of parent exception being handled. This should allow inner parts of pysnmp main loop functions to raise their own exceptions and user application to get hold of those above the main loop.

This change addresses issue https://github.com/etingof/pysnmp/issues/167 .