### PR TITLE
Fix out-of-scope OID leak in hlapi table

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Revision 4.4.5, released 2018-04-XX
 - Fixed `Bits` class initialization when enumeration values are given
 - Fixed crash caused by incoming SNMPv3 message requesting SNMPv1/v2c
   security model
+- Fixed out-of-scope OIDs leaking at the end of SNMP table at hlapi
+  `nextCmd` and `bulkCmd` calls when `lexicographicMode = False`
 
 Revision 4.4.4, released 2018-01-03
 -----------------------------------


### PR DESCRIPTION
Fixed out-of-scope OIDs possibly leaking at the end of SNMP table at hlapi `nextCmd` and `bulkCmd` calls when `lexicographicMode = False`.