### PR TITLE
Ensure tests run through tox are using the expected Python executable

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+PYTHON=${1:-python}
+
 for x in examples/hlapi/asyncore/sync/manager/cmdgen/*.py \
          examples/hlapi/asyncore/sync/agent/ntforg/*.py \
          examples/hlapi/asyncore/manager/cmdgen/*.py \
@@ -19,7 +21,7 @@ do
         continue
         ;;
     *)
-        python "${x}" | tail -50
+        $PYTHON "${x}" | tail -50
         ;;
     esac
 done

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [envlist]
-envlist = py{26,27,33,34,35,36}
+envlist = py{26,27,33,34,35,36,37}
 
 [testenv]
-commands = {toxinidir}/runtests.sh
+commands = {toxinidir}/runtests.sh {envpython}


### PR DESCRIPTION
Otherwise, they are likely to use the system python.