### PR TITLE
Fix compatibility with Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,6 @@ matrix:
     dist: xenial
     sudo: false
     python: '2.7'
-# Something is broken about pysnmp->pysnmpcrypto->cryptography.
-# Somehow pysnmpcrypto chooses cryptography while it should
-# pick pycryptodomex
-#  - os: linux
-#    dist: xenial
-#    sudo: false
-#    python: '3.2'
-  - os: linux
-    dist: xenial
-    sudo: false
-    python: '3.3'
   - os: linux
     dist: xenial
     sudo: false

--- a/pysnmp/carrier/asyncio/dgram/base.py
+++ b/pysnmp/carrier/asyncio/dgram/base.py
@@ -42,8 +42,6 @@ try:
 except ImportError:
     import trollius as asyncio
 
-IS_PYTHON_344_PLUS = platform.python_version_tuple() >= ('3', '4', '4')
-
 
 class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
     """Base Asyncio datagram Transport, to be used with AsyncioDispatcher"""
@@ -86,11 +84,7 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
             c = self.loop.create_datagram_endpoint(
                 lambda: self, local_addr=iface, family=self.sockFamily
             )
-            # Avoid deprecation warning for asyncio.async()
-            if IS_PYTHON_344_PLUS:
-              self._lport = asyncio.ensure_future(c)
-            else: # pragma: no cover
-              self._lport = asyncio.async(c)
+            self._lport = asyncio.ensure_future(c)
 
         except Exception:
             raise error.CarrierError(';'.join(traceback.format_exception(*sys.exc_info())))
@@ -101,7 +95,7 @@ class DgramAsyncioProtocol(asyncio.DatagramProtocol, AbstractAsyncioTransport):
             c = self.loop.create_datagram_endpoint(
                 lambda: self, local_addr=iface, family=self.sockFamily
             )
-            self._lport = asyncio.async(c)
+            self._lport = asyncio.ensure_future(c)
         except Exception:
             raise error.CarrierError(';'.join(traceback.format_exception(*sys.exc_info())))
         return self

--- a/pysnmp/carrier/asyncio/dispatch.py
+++ b/pysnmp/carrier/asyncio/dispatch.py
@@ -41,7 +41,6 @@ try:
 except ImportError:
     import trollius as asyncio
 
-IS_PYTHON_344_PLUS = platform.python_version_tuple() >= ('3', '4', '4')
 
 class AsyncioDispatcher(AbstractTransportDispatcher):
     """AsyncioDispatcher based on asyncio event loop"""
@@ -71,11 +70,7 @@ class AsyncioDispatcher(AbstractTransportDispatcher):
     
     def registerTransport(self, tDomain, transport):
         if self.loopingcall is None and self.getTimerResolution() > 0:
-            # Avoid deprecation warning for asyncio.async()
-            if IS_PYTHON_344_PLUS:
-              self.loopingcall = asyncio.ensure_future(self.handle_timeout())
-            else: # pragma: no cover
-              self.loopingcall = asyncio.async(self.handle_timeout())
+            self.loopingcall = asyncio.ensure_future(self.handle_timeout())
         AbstractTransportDispatcher.registerTransport(
             self, tDomain, transport
         )

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ Programming Language :: Python :: 2.5
 Programming Language :: Python :: 2.6
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.2
-Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [envlist]
-envlist = py{26,27,33,34,35,36}
+envlist = py{26,27,34,35,36,37}
 
 [testenv]
 commands = {toxinidir}/runtests.sh


### PR DESCRIPTION
In Python 3.7, async is a reserved keyword and cannot be used anymore
as a method or a variable without triggering a syntax error. The
compatibility with older versions of Python (3.2 and 3.3) need to be
removed.