### PR TITLE
Treat `None` community name/index as an empty string

### DIFF
--- a/pysnmp/hlapi/v1arch/auth.py
+++ b/pysnmp/hlapi/v1arch/auth.py
@@ -32,6 +32,9 @@ class CommunityData(object):
 
     def __init__(self, communityName, mpModel=1):
         self.mpModel = mpModel
+        # Treat `None` as an empty string
+        if communityName is None:
+            communityName = ''
         self.communityName = communityName
 
     def __hash__(self):

--- a/pysnmp/hlapi/v3arch/auth.py
+++ b/pysnmp/hlapi/v3arch/auth.py
@@ -107,6 +107,9 @@ class CommunityData(object):
             self.contextName = contextName
         if tag is not None:
             self.tag = tag
+        # Treat `None` as an empty string
+        if communityIndex is None:
+            communityIndex = ''
         # a single arg is considered as a community name
         if communityName is None:
             communityName, communityIndex = communityIndex, None


### PR DESCRIPTION
This change is to address issue #191 