### PR TITLE
Fix lcd.unconfigure not removing cached addr value preventing the same target being re-configured

### DIFF
--- a/pysnmp/hlapi/v3arch/lcd.py
+++ b/pysnmp/hlapi/v3arch/lcd.py
@@ -175,7 +175,7 @@ class CommandGeneratorLcdConfigurator(AbstractLcdConfigurator):
                     cache['addr'][addrKey] = addrName, useCount
                 else:
                     config.delTargetAddr(snmpEngine, addrName)
-
+                    del cache['addr'][addrKey]
                     addrNames.add(addrKey)
 
                     if addrKey[1] in cache['tran']:


### PR DESCRIPTION
`lcd.unconfigure` does not properly clean up its cache and can cause subsequent calls to fail with an error like: `pysnmp.smi.error.SmiError: Target a4010853008 not configured to LCD`.

This script will reproduce the error:
```python
from twisted.internet import defer, task
from pysnmp.entity import config, engine
from pysnmp.hlapi import UsmUserData, ContextData
from pysnmp.hlapi.v3arch.twisted.transport import UdpTransportTarget
from pysnmp.hlapi.v3arch.twisted.cmdgen import getCmd, lcd
from pysnmp.smi.rfc1902 import ObjectIdentity, ObjectType

def make_target(ip):
    return UdpTransportTarget(
        (ip, 1161),
        timeout=1,
        retries=0,
        tagList=''
    )

@defer.inlineCallbacks
def run(reactor):
    snmp_engine = engine.SnmpEngine()
    varbind = ObjectType(ObjectIdentity('1.3.6.1.2.1.1.5.0'))
    auth1 = UsmUserData(
        'testuser',
        authKey='foobar123',
        privKey='blahbar123',
        authProtocol=config.usmHMACSHAAuthProtocol,
        privProtocol=config.usmAesCfb128Protocol
    )
    target1 = make_target('127.0.0.1')
    target2 = make_target('127.0.0.2')

    result = yield getCmd(snmp_engine, auth1, target1, ContextData(), varbind)
    print(result)
    result = yield getCmd(snmp_engine, auth1, target2, ContextData(), varbind)
    print(result)
    lcd.unconfigure(snmp_engine, auth1)
    # this request will fail with "Target X not configured to LCD"
    result = yield getCmd(snmp_engine, auth1, target1, ContextData(), varbind)
    print(result)

task.react(run)
```