### PR TITLE
Convert to async MIB instrumentation API

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,9 +5,11 @@ Revision 5.0.0, released 2018-10-??
 - SNMPv3 crypto operations that require external dependencies
   made dependent on the optional external
   package -- pysnmpcrypto.
+
 - By switching to pysnmpcrypto, pysnmp effectively migrates from
   PyCryptodomex to pyca/cryptography whenever available on the
   platform.
+
 - Many really old backward-compatibility code snippets removed.
   Most importantly:
   
@@ -19,13 +21,14 @@ Revision 5.0.0, released 2018-10-??
 - The MIB instrumentation API overhauled in backward incompatible
   way:
 
-      - MIB instrumentation methods signatures simplified to accept
-        just var-binds (as var-arg), the rest of the parameters packed
-        into opaque kwargs
-      - CommandResponder application passes `snmpEngine` and optionally
-        user-supplied `cbCtx` object throughout the MIB instrumentation
-        methods. The goal is to let MIB objects access/modify whatever
-        custom Python objects they need while being called back.
+  * MIB instrumentation methods signatures simplified to accept
+    just var-binds (as var-arg), the rest of the parameters packed
+    into opaque kwargs
+  * CommandResponder application passes `snmpEngine` and optionally
+    user-supplied `cbCtx` object throughout the MIB instrumentation
+    methods. The goal is to let MIB objects access/modify whatever
+    custom Python objects they need while being called back.
+
 - The high-level API (`hlapi`) extended to cover lightweight SNMP v1arch
   in hope to ease the use of packet-level SNMP API.
 
@@ -41,6 +44,7 @@ Revision 5.0.0, released 2018-10-??
   automation around building well-formed SNMP messages is and mediating
   differences between SNMP versions is not present in this new `v1arch`
   layer.
+
 - The signature of the hlapi `.sendNotification()` call has changed
   to accept `*varBinds` instead of a sequence of `varBinds`. The rationale
   is to unify this method call with similar methods of CommandGenerator.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,10 +24,16 @@ Revision 5.0.0, released 2018-10-??
   * MIB instrumentation methods signatures simplified to accept
     just var-binds (as var-arg), the rest of the parameters packed
     into opaque kwargs
+
   * CommandResponder application passes `snmpEngine` and optionally
     user-supplied `cbCtx` object throughout the MIB instrumentation
     methods. The goal is to let MIB objects access/modify whatever
     custom Python objects they need while being called back.
+
+  * CommandResponder refactored to facilitate asynchronous
+    MIB instrumentation routines. The `readVars`, `readNextVars` and
+    `writeVars` MIB controller methods return immediately and
+    deliver their results via a call back.
 
 - The high-level API (`hlapi`) extended to cover lightweight SNMP v1arch
   in hope to ease the use of packet-level SNMP API.

--- a/examples/smi/agent/custom-managed-object.py
+++ b/examples/smi/agent/custom-managed-object.py
@@ -51,13 +51,23 @@ if __name__ == '__main__':
 
     mibInstrum = instrum.MibInstrumController(mibBuilder)
 
+    def cbFun(varBinds, **context):
+        for oid, val in varBinds:
+            if exval.endOfMib.isSameTypeWith(val):
+                context['state']['stop'] = True
+            print('%s = %s' % ('.'.join([str(x) for x in oid]), not val.isValue and 'N/A' or val.prettyPrint()))
+
+        context['state']['varBinds'] = varBinds
+
+    context = {
+        'cbFun': cbFun,
+        'state': {
+            'varBinds': [((1, 3, 6), None)],
+            'stop': False
+        }
+    }
+
     print('Remote manager read access to MIB instrumentation (table walk)')
-
-    varBinds = [((), None)]
-
-    while True:
-        varBinds = mibInstrum.readNextVars(*varBinds)
-        oid, val = varBinds[0]
-        if exval.endOfMib.isSameTypeWith(val):
-            break
-        print(oid, val.prettyPrint())
+    while not context['state']['stop']:
+        mibInstrum.readNextVars(*context['state']['varBinds'], **context)
+    print('done')

--- a/examples/v3arch/asyncore/agent/cmdrsp/custom-mib-controller.py
+++ b/examples/v3arch/asyncore/agent/cmdrsp/custom-mib-controller.py
@@ -54,7 +54,9 @@ snmpContext = context.SnmpContext(snmpEngine)
 # always echos request var-binds in response.
 class EchoMibInstrumController(instrum.AbstractMibInstrumController):
     def readVars(self, *varBinds, **context):
-        return [(ov[0], v2c.OctetString('You queried OID %s' % ov[0])) for ov in varBinds]
+        cbFun = context.get('cbFun')
+        if cbFun:
+            cbFun([(ov[0], v2c.OctetString('You queried OID %s' % ov[0])) for ov in varBinds], **context)
 
 
 # Create a custom Management Instrumentation Controller and register at

--- a/pysnmp/entity/config.py
+++ b/pysnmp/entity/config.py
@@ -422,7 +422,8 @@ def delContext(snmpEngine, contextName):
     vacmContextEntry, tblIdx = __cookVacmContextInfo(snmpEngine, contextName)
 
     snmpEngine.msgAndPduDsp.mibInstrumController.writeVars(
-        (vacmContextEntry.name + (2,) + tblIdx, 'destroy')
+        (vacmContextEntry.name + (2,) + tblIdx, 'destroy'),
+        ** dict(snmpEngine=snmpEngine)
     )
 
 

--- a/pysnmp/smi/instrum.py
+++ b/pysnmp/smi/instrum.py
@@ -183,16 +183,100 @@ class MibInstrumController(AbstractMibInstrumController):
 
     # MIB instrumentation
 
-    def flipFlopFsm(self, fsmTable, *varBinds, **context):
-        self.__indexMib()
+    @staticmethod
+    def _collectVarBindsCb(varBind, cbCtx, **context):
+        cbFun, (cbCtx, idx, varBindsLen, collectedVarBinds) = cbCtx
 
-        debug.logger & debug.flagIns and debug.logger('flipFlopFsm: input var-binds %r' % (varBinds,))
+        if len(collectedVarBinds) < varBindsLen:
+            collectedVarBinds[idx] = varBind
+            return
+
+        varBinds = [vb[1] for vb in sorted(collectedVarBinds.items(), key=lambda x: x[0])]
+
+        cbFun(varBinds, cbCtx, **context)
+
+    @staticmethod
+    def _flipFlopFsmCb(varBinds, cbCtx, **context):
+        cbFun, (cbCtx, state) = cbCtx
+
+        if any([varBind for varBind in varBinds if isinstance(varBind[1], Exception)]):
+            status = 'err'
+            
+        debug.logger & debug.flagIns and debug.logger(
+            '_flipFlopFsmCb: current state %s, status %s' % (state, status))
+
+        try:
+            newState = fsmTable[(state, status)]
+
+        except KeyError:
+            try:
+                newState = fsmTable[('*', status)]
+
+            except KeyError:
+                raise error.SmiError(
+                    'Unresolved FSM state %s, %s' % (state, status)
+                )
+
+            debug.logger & debug.flagIns and debug.logger(
+                '_flipFlopFsmCb: state %s status %s -> new state %s' % (state, status, newState))
+
+        state = newState
+        status = 'ok'
+
+        if state == 'stop':
+            cbFun(varBinds, cbCtx, **context)
+            return
+
+        mgmtFun = getattr(mibTree, state, None)
+        if not mgmtFun:
+            raise error.SmiError(
+                'Unsupported state handler %s at %s' % (state, self)
+            )
+
+        collectedVarBinds = {}
+
+        for idx, (name, val) in enumerate(varBinds):
+            _cbCtx = self._flipFlopFsmCb, (cbCtx, idx, len(varBinds), collectedVarBinds)
+
+            varBind = (tuple(name), val)
+
+            try:
+                mgmtFun(varBind, self._collectVarBindsCb, _cbCtx, **context)
+
+            except error.SmiError:
+                exc = sys.exc_info()
+                debug.logger & debug.flagIns and debug.logger(
+                    '_flipFlopFsmCb: fun %s exception %s for %r with traceback: %s' % (
+                        mgmtFun, exc[0], varBind, traceback.format_exception(*exc)))
+
+                varBind = name, exc
+
+                self._collectVarBindsCb(varBind, _cbCtx, **context)
+
+            else:
+                debug.logger & debug.flagIns and debug.logger(
+                    '_flipFlopFsmCb: func %s succeeded for %r' % (mgmtFun, varBind))
+
+    def flipFlopFsm(self, fsmTable, *varBinds, **context):
+
+        try:
+            fsmContext = context['fsmState']
+
+        except KeyError:
+            self.__indexMib()
+
+            fsmContext = context['fsmState'] = dict(varBinds=[], state='start', status='ok')
+
+            debug.logger & debug.flagIns and debug.logger('flipFlopFsm: input var-binds %r' % (varBinds,))
 
         mibTree, = self.mibBuilder.importSymbols('SNMPv2-SMI', 'iso')
 
-        outputVarBinds = []
-        state, status = 'start', 'ok'
+        outputVarBinds = fsmContext['varBinds']
+        state = fsmContext['state']
+        status = fsmContext['status']
+
         origExc = origTraceback = None
+
         while True:
             k = state, status
             if k in fsmTable:


### PR DESCRIPTION
MIB instrumentation API changed to allow for asynchronous
managed objects access. Although built-in SNMPv2-SMI objects
are still synchronous, the MIB instrumentation API is async
what allows users to replace default MIB instrumentation
with their own, potentially asynchronous.
    
SMI/MIB managed objects API overhauled for simplicity and
flexibility breaking backward compatibility.
