### PR TITLE
Refactor MIB state machine into asynchronous operations

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -25,15 +25,17 @@ Revision 5.0.0, released 2018-10-??
     just var-binds (as var-arg), the rest of the parameters packed
     into opaque kwargs
 
+  * The `readVars`, `readNextVars` and `writeVars` methods of MIB
+    instrumentation controller return immediately and deliver their
+    results via a call back.
+
   * CommandResponder application passes `snmpEngine` and optionally
     user-supplied `cbCtx` object throughout the MIB instrumentation
     methods. The goal is to let MIB objects access/modify whatever
     custom Python objects they need while being called back.
 
   * CommandResponder refactored to facilitate asynchronous
-    MIB instrumentation routines. The `readVars`, `readNextVars` and
-    `writeVars` MIB controller methods return immediately and
-    deliver their results via a call back.
+    MIB instrumentation routines.
 
 - The high-level API (`hlapi`) extended to cover lightweight SNMP v1arch
   in hope to ease the use of packet-level SNMP API.

--- a/examples/v3arch/asyncore/agent/cmdrsp/implementing-scalar-mib-objects.py
+++ b/examples/v3arch/asyncore/agent/cmdrsp/implementing-scalar-mib-objects.py
@@ -56,7 +56,7 @@ MibScalar, MibScalarInstance = mibBuilder.importSymbols(
 
 class MyStaticMibScalarInstance(MibScalarInstance):
     # noinspection PyUnusedLocal,PyUnusedLocal
-    def getValue(self, name, idx):
+    def getValue(self, name, idx, **context):
         return self.getSyntax().clone(
             'Python %s running on a %s platform' % (sys.version, sys.platform)
         )

--- a/examples/v3arch/asyncore/proxy/command/ipv6-to-ipv4-conversion.py
+++ b/examples/v3arch/asyncore/proxy/command/ipv6-to-ipv4-conversion.py
@@ -96,7 +96,7 @@ class CommandResponder(cmdrsp.CommandResponderBase):
         v2c.GetNextRequestPDU.tagSet: cmdgen.NextCommandGeneratorSingleRun(),
         v2c.GetBulkRequestPDU.tagSet: cmdgen.BulkCommandGeneratorSingleRun()
     }
-    pduTypes = cmdGenMap.keys()  # This app will handle these PDUs
+    SUPPORTED_PDU_TYPES = cmdGenMap.keys()  # This app will handle these PDUs
 
     # SNMP request relay
     def handleMgmtOperation(self, snmpEngine, stateReference, contextName,

--- a/examples/v3arch/asyncore/proxy/command/v2c-to-v1-conversion.py
+++ b/examples/v3arch/asyncore/proxy/command/v2c-to-v1-conversion.py
@@ -95,7 +95,7 @@ class CommandResponder(cmdrsp.CommandResponderBase):
         v2c.GetNextRequestPDU.tagSet: cmdgen.NextCommandGeneratorSingleRun(),
         v2c.GetBulkRequestPDU.tagSet: cmdgen.BulkCommandGeneratorSingleRun()
     }
-    pduTypes = cmdGenMap.keys()  # This app will handle these PDUs
+    SUPPORTED_PDU_TYPES = cmdGenMap.keys()  # This app will handle these PDUs
 
     # SNMP request relay
     def handleMgmtOperation(self, snmpEngine, stateReference, contextName,

--- a/examples/v3arch/asyncore/proxy/command/v2c-to-v3-conversion.py
+++ b/examples/v3arch/asyncore/proxy/command/v2c-to-v3-conversion.py
@@ -95,7 +95,7 @@ class CommandResponder(cmdrsp.CommandResponderBase):
         v2c.GetNextRequestPDU.tagSet: cmdgen.NextCommandGeneratorSingleRun(),
         v2c.GetBulkRequestPDU.tagSet: cmdgen.BulkCommandGeneratorSingleRun()
     }
-    pduTypes = cmdGenMap.keys()  # This app will handle these PDUs
+    SUPPORTED_PDU_TYPES = cmdGenMap.keys()  # This app will handle these PDUs
 
     # SNMP request relay
     def handleMgmtOperation(self, snmpEngine, stateReference, contextName,

--- a/examples/v3arch/asyncore/proxy/command/v3-to-v2c-conversion.py
+++ b/examples/v3arch/asyncore/proxy/command/v3-to-v2c-conversion.py
@@ -98,7 +98,7 @@ class CommandResponder(cmdrsp.CommandResponderBase):
         v2c.GetNextRequestPDU.tagSet: cmdgen.NextCommandGeneratorSingleRun(),
         v2c.GetBulkRequestPDU.tagSet: cmdgen.BulkCommandGeneratorSingleRun()
     }
-    pduTypes = cmdGenMap.keys()  # This app will handle these PDUs
+    SUPPORTED_PDU_TYPES = cmdGenMap.keys()  # This app will handle these PDUs
 
     # SNMP request relay
     def handleMgmtOperation(self, snmpEngine, stateReference, contextName,

--- a/pysnmp/entity/rfc3413/ntfrcv.py
+++ b/pysnmp/entity/rfc3413/ntfrcv.py
@@ -14,12 +14,12 @@ from pysnmp import debug
 
 # 3.4
 class NotificationReceiver(object):
-    pduTypes = (v1.TrapPDU.tagSet, v2c.SNMPv2TrapPDU.tagSet,
-                v2c.InformRequestPDU.tagSet)
+    SUPPORTED_PDU_TYPES = (v1.TrapPDU.tagSet, v2c.SNMPv2TrapPDU.tagSet,
+                           v2c.InformRequestPDU.tagSet)
 
     def __init__(self, snmpEngine, cbFun, cbCtx=None):
         snmpEngine.msgAndPduDsp.registerContextEngineId(
-            null, self.pduTypes, self.processPdu  # '' is a wildcard
+            null, self.SUPPORTED_PDU_TYPES, self.processPdu  # '' is a wildcard
         )
 
         self.__snmpTrapCommunity = ''
@@ -33,7 +33,7 @@ class NotificationReceiver(object):
 
     def close(self, snmpEngine):
         snmpEngine.msgAndPduDsp.unregisterContextEngineId(
-            null, self.pduTypes
+            null, self.SUPPORTED_PDU_TYPES
         )
         self.__cbFun = self.__cbCtx = None
 

--- a/pysnmp/smi/instrum.py
+++ b/pysnmp/smi/instrum.py
@@ -6,6 +6,8 @@
 #
 import sys
 import traceback
+import functools
+from pysnmp import nextid
 from pysnmp.smi import error
 from pysnmp import debug
 
@@ -24,38 +26,58 @@ class AbstractMibInstrumController(object):
 
 
 class MibInstrumController(AbstractMibInstrumController):
+    STATUS_OK = 'ok'
+    STATUS_ERROR = 'err'
+    
+    STATE_START = 'start'
+    STATE_STOP = 'stop'
+    STATE_ANY = '*'
+    # These states are actually methods of the MIB objects
+    STATE_READ_TEST = 'readTest'
+    STATE_READ_GET = 'readGet'
+    STATE_READ_TEST_NEXT = 'readTestNext'
+    STATE_READ_GET_NEXT = 'readGetNext'
+    STATE_WRITE_TEST = 'writeTest'
+    STATE_WRITE_COMMIT = 'writeCommit'
+    STATE_WRITE_CLEANUP = 'writeCleanup'
+    STATE_WRITE_UNDO = 'writeUndo'
+
     fsmReadVar = {
         # ( state, status ) -> newState
-        ('start', 'ok'): 'readTest',
-        ('readTest', 'ok'): 'readGet',
-        ('readGet', 'ok'): 'stop',
-        ('*', 'err'): 'stop'
+        (STATE_START, STATUS_OK): STATE_READ_TEST,
+        (STATE_READ_TEST, STATUS_OK): STATE_READ_GET,
+        (STATE_READ_GET, STATUS_OK): STATE_STOP,
+        (STATE_ANY, STATUS_ERROR): STATE_STOP
     }
     fsmReadNextVar = {
         # ( state, status ) -> newState
-        ('start', 'ok'): 'readTestNext',
-        ('readTestNext', 'ok'): 'readGetNext',
-        ('readGetNext', 'ok'): 'stop',
-        ('*', 'err'): 'stop'
+        (STATE_START, STATUS_OK): STATE_READ_TEST_NEXT,
+        (STATE_READ_TEST_NEXT, STATUS_OK): STATE_READ_GET_NEXT,
+        (STATE_READ_GET_NEXT, STATUS_OK): STATE_STOP,
+        (STATE_ANY, STATUS_ERROR): STATE_STOP
     }
     fsmWriteVar = {
         # ( state, status ) -> newState
-        ('start', 'ok'): 'writeTest',
-        ('writeTest', 'ok'): 'writeCommit',
-        ('writeCommit', 'ok'): 'writeCleanup',
-        ('writeCleanup', 'ok'): 'readTest',
+        (STATE_START, STATUS_OK): STATE_WRITE_TEST,
+        (STATE_WRITE_TEST, STATUS_OK): STATE_WRITE_COMMIT,
+        (STATE_WRITE_COMMIT, STATUS_OK): STATE_WRITE_CLEANUP,
+        (STATE_WRITE_CLEANUP, STATUS_OK): STATE_READ_TEST,
         # Do read after successful write
-        ('readTest', 'ok'): 'readGet',
-        ('readGet', 'ok'): 'stop',
+        (STATE_READ_TEST, STATUS_OK): STATE_READ_GET,
+        (STATE_READ_GET, STATUS_OK): STATE_STOP,
         # Error handling
-        ('writeTest', 'err'): 'writeCleanup',
-        ('writeCommit', 'err'): 'writeUndo',
-        ('writeUndo', 'ok'): 'readTest',
+        (STATE_WRITE_TEST, STATUS_ERROR): STATE_WRITE_CLEANUP,
+        (STATE_WRITE_COMMIT, STATUS_ERROR): STATE_WRITE_UNDO,
+        (STATE_WRITE_UNDO, STATUS_OK): STATE_READ_TEST,
         # Ignore read errors (removed columns)
-        ('readTest', 'err'): 'stop',
-        ('readGet', 'err'): 'stop',
-        ('*', 'err'): 'stop'
+        (STATE_READ_TEST, STATUS_ERROR): STATE_STOP,
+        (STATE_READ_GET, STATUS_ERROR): STATE_STOP,
+        (STATE_ANY, STATUS_ERROR): STATE_STOP
     }
+
+    FSM_CONTEXT = '_fsmContext'
+
+    FSM_SESSION_ID = nextid.Integer(0xffffffff)
 
     def __init__(self, mibBuilder):
         self.mibBuilder = mibBuilder
@@ -183,49 +205,85 @@ class MibInstrumController(AbstractMibInstrumController):
 
     # MIB instrumentation
 
-    @staticmethod
-    def _collectVarBindsCb(varBind, cbCtx, **context):
-        cbFun, (cbCtx, idx, varBindsLen, collectedVarBinds) = cbCtx
+    def _flipFlopFsmCb(self, varBind, **context):
+        fsmContext = context[self.FSM_CONTEXT]
 
-        if len(collectedVarBinds) < varBindsLen:
-            collectedVarBinds[idx] = varBind
-            return
+        varBinds = fsmContext['varBinds']
 
-        varBinds = [vb[1] for vb in sorted(collectedVarBinds.items(), key=lambda x: x[0])]
+        idx = context.pop('idx')
 
-        cbFun(varBinds, cbCtx, **context)
+        if idx >= 0:
+            fsmContext['count'] += 1
 
-    @staticmethod
-    def _flipFlopFsmCb(varBinds, cbCtx, **context):
-        cbFun, (cbCtx, state) = cbCtx
+            varBinds[idx] = varBind
 
-        if any([varBind for varBind in varBinds if isinstance(varBind[1], Exception)]):
-            status = 'err'
-            
+            debug.logger & debug.flagIns and debug.logger(
+                '_flipFlopFsmCb: var-bind %d, processed %d, expected %d' % (idx, fsmContext['count'], len(varBinds)))
+
+            if fsmContext['count'] < len(varBinds):
+                return
+
         debug.logger & debug.flagIns and debug.logger(
-            '_flipFlopFsmCb: current state %s, status %s' % (state, status))
+            '_flipFlopFsmCb: finished, output %r' % (varBinds,))
+
+        fsmCallable = fsmContext['fsmCallable']
+
+        fsmCallable(**context)
+
+    def flipFlopFsm(self, fsmTable, *varBinds, **context):
+        try:
+            fsmContext = context[self.FSM_CONTEXT]
+
+        except KeyError:
+            self.__indexMib()
+
+            fsmContext = context[self.FSM_CONTEXT] = dict(
+                sessionId=self.FSM_SESSION_ID(),
+                varBinds=list(varBinds[:]),
+                fsmCallable=functools.partial(self.flipFlopFsm, fsmTable, *varBinds),
+                state=self.STATE_START, status=self.STATUS_OK
+            )
+
+            debug.logger & debug.flagIns and debug.logger('flipFlopFsm: input var-binds %r' % (varBinds,))
+
+        mibTree, = self.mibBuilder.importSymbols('SNMPv2-SMI', 'iso')
+
+        state = fsmContext['state']
+        status = fsmContext['status']
+
+        debug.logger & debug.flagIns and debug.logger(
+            'flipFlopFsm: current state %s, status %s' % (state, status))
 
         try:
             newState = fsmTable[(state, status)]
 
         except KeyError:
             try:
-                newState = fsmTable[('*', status)]
+                newState = fsmTable[(self.STATE_ANY, status)]
 
             except KeyError:
-                raise error.SmiError(
-                    'Unresolved FSM state %s, %s' % (state, status)
-                )
+                raise error.SmiError('Unresolved FSM state %s, %s' % (state, status))
 
-            debug.logger & debug.flagIns and debug.logger(
-                '_flipFlopFsmCb: state %s status %s -> new state %s' % (state, status, newState))
+        debug.logger & debug.flagIns and debug.logger(
+            'flipFlopFsm: state %s status %s -> new state %s' % (state, status, newState))
 
         state = newState
-        status = 'ok'
 
-        if state == 'stop':
-            cbFun(varBinds, cbCtx, **context)
+        if state == self.STATE_STOP:
+            context.pop(self.FSM_CONTEXT, None)
+
+            cbFun = context.get('cbFun')
+            if cbFun:
+                varBinds = fsmContext['varBinds']
+                cbFun(varBinds, **context)
+
             return
+
+        fsmContext.update(state=state, count=0)
+
+        # the case of no var-binds
+        if not varBinds:
+            return self._flipFlopFsmCb(None, idx=-1, **context)
 
         mgmtFun = getattr(mibTree, state, None)
         if not mgmtFun:
@@ -233,112 +291,29 @@ class MibInstrumController(AbstractMibInstrumController):
                 'Unsupported state handler %s at %s' % (state, self)
             )
 
-        collectedVarBinds = {}
-
-        for idx, (name, val) in enumerate(varBinds):
-            _cbCtx = self._flipFlopFsmCb, (cbCtx, idx, len(varBinds), collectedVarBinds)
-
-            varBind = (tuple(name), val)
-
+        for idx, varBind in enumerate(varBinds):
             try:
-                mgmtFun(varBind, self._collectVarBindsCb, _cbCtx, **context)
+                # TODO: managed objects to run asynchronously
+                #mgmtFun(varBind, idx=idx, **context)
+                self._flipFlopFsmCb(mgmtFun(varBind, idx=idx, **context), idx=idx, **context)
 
             except error.SmiError:
                 exc = sys.exc_info()
                 debug.logger & debug.flagIns and debug.logger(
-                    '_flipFlopFsmCb: fun %s exception %s for %r with traceback: %s' % (
+                    'flipFlopFsm: fun %s exception %s for %r with traceback: %s' % (
                         mgmtFun, exc[0], varBind, traceback.format_exception(*exc)))
 
-                varBind = name, exc
+                varBind = varBind[0], exc
 
-                self._collectVarBindsCb(varBind, _cbCtx, **context)
+                fsmContext['status'] = self.STATUS_ERROR
+
+                self._flipFlopFsmCb(varBind, idx=idx, **context)
+
+                return
 
             else:
                 debug.logger & debug.flagIns and debug.logger(
-                    '_flipFlopFsmCb: func %s succeeded for %r' % (mgmtFun, varBind))
-
-    def flipFlopFsm(self, fsmTable, *varBinds, **context):
-
-        try:
-            fsmContext = context['fsmState']
-
-        except KeyError:
-            self.__indexMib()
-
-            fsmContext = context['fsmState'] = dict(varBinds=[], state='start', status='ok')
-
-            debug.logger & debug.flagIns and debug.logger('flipFlopFsm: input var-binds %r' % (varBinds,))
-
-        mibTree, = self.mibBuilder.importSymbols('SNMPv2-SMI', 'iso')
-
-        outputVarBinds = fsmContext['varBinds']
-        state = fsmContext['state']
-        status = fsmContext['status']
-
-        origExc = origTraceback = None
-
-        while True:
-            k = state, status
-            if k in fsmTable:
-                fsmState = fsmTable[k]
-            else:
-                k = '*', status
-                if k in fsmTable:
-                    fsmState = fsmTable[k]
-                else:
-                    raise error.SmiError(
-                        'Unresolved FSM state %s, %s' % (state, status)
-                    )
-            debug.logger & debug.flagIns and debug.logger(
-                'flipFlopFsm: state %s status %s -> fsmState %s' % (state, status, fsmState))
-            state = fsmState
-            status = 'ok'
-            if state == 'stop':
-                break
-
-            for idx, (name, val) in enumerate(varBinds):
-                mgmtFun = getattr(mibTree, state, None)
-                if not mgmtFun:
-                    raise error.SmiError(
-                        'Unsupported state handler %s at %s' % (state, self)
-                    )
-
-                context['idx'] = idx
-
-                try:
-                    # Convert to tuple to avoid ObjectName instantiation
-                    # on subscription
-                    rval = mgmtFun((tuple(name), val), **context)
-
-                except error.SmiError:
-                    exc_t, exc_v, exc_tb = sys.exc_info()
-                    debug.logger & debug.flagIns and debug.logger(
-                        'flipFlopFsm: fun %s exception %s for %s=%r with traceback: %s' % (
-                            mgmtFun, exc_t, name, val, traceback.format_exception(exc_t, exc_v, exc_tb)))
-                    if origExc is None:  # Take the first exception
-                        origExc, origTraceback = exc_v, exc_tb
-                    status = 'err'
-                    break
-                else:
-                    debug.logger & debug.flagIns and debug.logger(
-                        'flipFlopFsm: fun %s succeeded for %s=%r' % (mgmtFun, name, val))
-                    if rval is not None:
-                        outputVarBinds.append((rval[0], rval[1]))
-
-        if origExc:
-            if sys.version_info[0] <= 2:
-                raise origExc
-            else:
-                try:
-                    raise origExc.with_traceback(origTraceback)
-                finally:
-                    # Break cycle between locals and traceback object
-                    # (seems to be irrelevant on Py3 but just in case)
-                    del origTraceback
-
-        cbFun = context.get('cbFun')
-        if cbFun:
-            cbFun(outputVarBinds, **context)
+                    'flipFlopFsm: func %s initiated for %r' % (mgmtFun, varBind))
 
     def readVars(self, *varBinds, **context):
         self.flipFlopFsm(self.fsmReadVar, *varBinds, **context)

--- a/pysnmp/smi/instrum.py
+++ b/pysnmp/smi/instrum.py
@@ -183,6 +183,80 @@ class MibInstrumController(AbstractMibInstrumController):
 
     # MIB instrumentation
 
+    @staticmethod
+    def _collectVarBindsCb(varBind, cbCtx, **context):
+        cbFun, (cbCtx, idx, varBindsLen, collectedVarBinds) = cbCtx
+
+        if len(collectedVarBinds) < varBindsLen:
+            collectedVarBinds[idx] = varBind
+            return
+
+        varBinds = [vb[1] for vb in sorted(collectedVarBinds.items(), key=lambda x: x[0])]
+
+        cbFun(varBinds, cbCtx, **context)
+
+    @staticmethod
+    def _flipFlopFsmCb(varBinds, cbCtx, **context):
+        cbFun, (cbCtx, state) = cbCtx
+
+        if any([varBind for varBind in varBinds if isinstance(varBind[1], Exception)]):
+            status = 'err'
+            
+        debug.logger & debug.flagIns and debug.logger(
+            '_flipFlopFsmCb: current state %s, status %s' % (state, status))
+
+        try:
+            newState = fsmTable[(state, status)]
+
+        except KeyError:
+            try:
+                newState = fsmTable[('*', status)]
+
+            except KeyError:
+                raise error.SmiError(
+                    'Unresolved FSM state %s, %s' % (state, status)
+                )
+
+            debug.logger & debug.flagIns and debug.logger(
+                '_flipFlopFsmCb: state %s status %s -> new state %s' % (state, status, newState))
+
+        state = newState
+        status = 'ok'
+
+        if state == 'stop':
+            cbFun(varBinds, cbCtx, **context)
+            return
+
+        mgmtFun = getattr(mibTree, state, None)
+        if not mgmtFun:
+            raise error.SmiError(
+                'Unsupported state handler %s at %s' % (state, self)
+            )
+
+        collectedVarBinds = {}
+
+        for idx, (name, val) in enumerate(varBinds):
+            _cbCtx = self._flipFlopFsmCb, (cbCtx, idx, len(varBinds), collectedVarBinds)
+
+            varBind = (tuple(name), val)
+
+            try:
+                mgmtFun(varBind, self._collectVarBindsCb, _cbCtx, **context)
+
+            except error.SmiError:
+                exc = sys.exc_info()
+                debug.logger & debug.flagIns and debug.logger(
+                    '_flipFlopFsmCb: fun %s exception %s for %r with traceback: %s' % (
+                        mgmtFun, exc[0], varBind, traceback.format_exception(*exc)))
+
+                varBind = name, exc
+
+                self._collectVarBindsCb(varBind, _cbCtx, **context)
+
+            else:
+                debug.logger & debug.flagIns and debug.logger(
+                    '_flipFlopFsmCb: func %s succeeded for %r' % (mgmtFun, varBind))
+
     def flipFlopFsm(self, fsmTable, *varBinds, **context):
 
         try:


### PR DESCRIPTION
When MIB instrumentation controller reads or writes managed objects, it does so in transactional manner e.g. going through a sequence of method calls for each managed object.
    
This commit refactors the MIB instrumentation methods being called by the state machine to return immediately and resume once the callback is called.
    
This change is a prerequisite for fully asynchronous managed objects implementation.
