### PR TITLE
Fix hlapi LCD to include `contextName`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ Revision 4.4.7, released 2018-11-XX
   the stack frames (ultimately shown in traceback/debugger)
 - Fixed hlapi/v3arch transport target caching to ensure transport targets
   are different even if just timeout/retries options differ
+- Fixed hlapi LCD configurator to include `contextName`. Prior to this fix
+  sending SNMPv3 TRAP with non-default `contextName` would fail.
 
 Revision 4.4.6, released 2018-09-13
 -----------------------------------

--- a/pysnmp/entity/config.py
+++ b/pysnmp/entity/config.py
@@ -560,12 +560,13 @@ def addVacmUser(snmpEngine, securityModel, securityName, securityLevel,
 
 
 def delVacmUser(snmpEngine, securityModel, securityName, securityLevel,
-                readSubTree=(), writeSubTree=(), notifySubTree=()):
+                readSubTree=(), writeSubTree=(), notifySubTree=(),
+                contextName=null):
     (groupName, securityLevel, readView, writeView,
      notifyView) = __cookVacmUserInfo(snmpEngine, securityModel,
                                       securityName, securityLevel)
     delVacmGroup(snmpEngine, securityModel, securityName)
-    delVacmAccess(snmpEngine, groupName, null, securityModel, securityLevel)
+    delVacmAccess(snmpEngine, groupName, contextName, securityModel, securityLevel)
     if readSubTree:
         delVacmView(
             snmpEngine, readView, readSubTree
@@ -582,36 +583,40 @@ def delVacmUser(snmpEngine, securityModel, securityName, securityLevel,
 
 # Obsolete shortcuts for add/delVacmUser() wrappers
 
-def addRoUser(snmpEngine, securityModel, securityName, securityLevel, subTree):
-    addVacmUser(snmpEngine, securityModel, securityName,
-                securityLevel, subTree)
-
-
-def delRoUser(snmpEngine, securityModel, securityName, securityLevel, subTree):
-    delVacmUser(snmpEngine, securityModel, securityName, securityLevel,
-                subTree)
-
-
-def addRwUser(snmpEngine, securityModel, securityName, securityLevel, subTree):
+def addRoUser(snmpEngine, securityModel, securityName, securityLevel,
+              subTree, contextName=null):
     addVacmUser(snmpEngine, securityModel, securityName, securityLevel,
-                subTree, subTree)
+                subTree, contextName=contextName)
 
 
-def delRwUser(snmpEngine, securityModel, securityName, securityLevel, subTree):
+def delRoUser(snmpEngine, securityModel, securityName, securityLevel,
+              subTree, contextName=null):
     delVacmUser(snmpEngine, securityModel, securityName, securityLevel,
-                subTree, subTree)
+                subTree, contextName=contextName)
+
+
+def addRwUser(snmpEngine, securityModel, securityName, securityLevel,
+              subTree, contextName=null):
+    addVacmUser(snmpEngine, securityModel, securityName, securityLevel,
+                subTree, subTree, contextName=contextName)
+
+
+def delRwUser(snmpEngine, securityModel, securityName, securityLevel,
+              subTree, contextName=null):
+    delVacmUser(snmpEngine, securityModel, securityName, securityLevel,
+                subTree, subTree, contextName=contextName)
 
 
 def addTrapUser(snmpEngine, securityModel, securityName,
-                securityLevel, subTree):
+                securityLevel, subTree, contextName=null):
     addVacmUser(snmpEngine, securityModel, securityName, securityLevel,
-                (), (), subTree)
+                (), (), subTree, contextName=contextName)
 
 
 def delTrapUser(snmpEngine, securityModel, securityName,
-                securityLevel, subTree):
+                securityLevel, subTree, contextName=null):
     delVacmUser(snmpEngine, securityModel, securityName, securityLevel,
-                (), (), subTree)
+                (), (), subTree, contextName=contextName)
 
 
 # Notification target setup

--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -148,7 +148,8 @@ def getCmd(snmpEngine, authData, transportTarget, contextData,
                 (errorIndication, errorStatus, errorIndex, varBindsUnmade)
             )
 
-    addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
+    addrName, paramsName = lcd.configure(
+        snmpEngine, authData, transportTarget, contextData.contextName)
 
     future = asyncio.Future()
 
@@ -254,7 +255,8 @@ def setCmd(snmpEngine, authData, transportTarget, contextData,
                 (errorIndication, errorStatus, errorIndex, varBindsUnmade)
             )
 
-    addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
+    addrName, paramsName = lcd.configure(
+        snmpEngine, authData, transportTarget, contextData.contextName)
 
     future = asyncio.Future()
 
@@ -366,7 +368,8 @@ def nextCmd(snmpEngine, authData, transportTarget, contextData,
                 (errorIndication, errorStatus, errorIndex, varBindsUnmade)
             )
 
-    addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
+    addrName, paramsName = lcd.configure(
+        snmpEngine, authData, transportTarget, contextData.contextName)
 
     future = asyncio.Future()
 
@@ -507,7 +510,8 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
                 (errorIndication, errorStatus, errorIndex, varBindsUnmade)
             )
 
-    addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
+    addrName, paramsName = lcd.configure(
+        snmpEngine, authData, transportTarget, contextData.contextName)
 
     future = asyncio.Future()
 

--- a/pysnmp/hlapi/asyncio/ntforg.py
+++ b/pysnmp/hlapi/asyncio/ntforg.py
@@ -139,8 +139,8 @@ def sendNotification(snmpEngine, authData, transportTarget, contextData,
             )
 
     notifyName = lcd.configure(
-        snmpEngine, authData, transportTarget, notifyType
-    )
+        snmpEngine, authData, transportTarget, notifyType,
+        contextData.contextName)
 
     future = asyncio.Future()
 

--- a/pysnmp/hlapi/asyncore/cmdgen.py
+++ b/pysnmp/hlapi/asyncore/cmdgen.py
@@ -121,7 +121,8 @@ def getCmd(snmpEngine, authData, transportTarget, contextData,
                              snmpEngine, varBinds, lookupMib
                          ), cbCtx)
 
-    addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
+    addrName, paramsName = lcd.configure(
+        snmpEngine, authData, transportTarget, contextData.contextName)
 
     return cmdgen.GetCommandGenerator().sendVarBinds(
         snmpEngine, addrName, contextData.contextEngineId,
@@ -232,7 +233,8 @@ def setCmd(snmpEngine, authData, transportTarget, contextData,
                          snmpEngine, varBinds, lookupMib
                      ), cbCtx)
 
-    addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
+    addrName, paramsName = lcd.configure(
+        snmpEngine, authData, transportTarget, contextData.contextName)
 
     return cmdgen.SetCommandGenerator().sendVarBinds(
         snmpEngine, addrName, contextData.contextEngineId,
@@ -343,7 +345,9 @@ def nextCmd(snmpEngine, authData, transportTarget, contextData,
                       varBindTable],
                      cbCtx)
 
-    addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
+    addrName, paramsName = lcd.configure(
+        snmpEngine, authData, transportTarget, contextData.contextName)
+
     return cmdgen.NextCommandGenerator().sendVarBinds(
         snmpEngine, addrName,
         contextData.contextEngineId, contextData.contextName,
@@ -483,7 +487,9 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
                      [vbProcessor.unmakeVarBinds(snmpEngine, varBindTableRow, lookupMib) for varBindTableRow in
                       varBindTable], cbCtx)
 
-    addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
+    addrName, paramsName = lcd.configure(
+        snmpEngine, authData, transportTarget, contextData.contextName)
+
     return cmdgen.BulkCommandGenerator().sendVarBinds(
         snmpEngine, addrName, contextData.contextEngineId,
         contextData.contextName, nonRepeaters, maxRepetitions,

--- a/pysnmp/hlapi/asyncore/ntforg.py
+++ b/pysnmp/hlapi/asyncore/ntforg.py
@@ -131,7 +131,7 @@ def sendNotification(snmpEngine, authData, transportTarget, contextData,
         )
 
     notifyName = lcd.configure(snmpEngine, authData, transportTarget,
-                               notifyType)
+                               notifyType, contextData.contextName)
 
     return ntforg.NotificationOriginator().sendVarBinds(
         snmpEngine, notifyName,

--- a/pysnmp/hlapi/twisted/cmdgen.py
+++ b/pysnmp/hlapi/twisted/cmdgen.py
@@ -129,7 +129,8 @@ def getCmd(snmpEngine, authData, transportTarget, contextData,
             else:
                 deferred.callback((errorStatus, errorIndex, varBindsUnmade))
 
-    addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
+    addrName, paramsName = lcd.configure(
+        snmpEngine, authData, transportTarget, contextData.contextName)
 
     deferred = Deferred()
 
@@ -246,7 +247,8 @@ def setCmd(snmpEngine, authData, transportTarget, contextData,
             else:
                 deferred.callback((errorStatus, errorIndex, varBindsUnmade))
 
-    addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
+    addrName, paramsName = lcd.configure(
+        snmpEngine, authData, transportTarget, contextData.contextName)
 
     deferred = Deferred()
 
@@ -377,7 +379,8 @@ def nextCmd(snmpEngine, authData, transportTarget, contextData,
             else:
                 deferred.callback((errorStatus, errorIndex, varBindsUnmade))
 
-    addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
+    addrName, paramsName = lcd.configure(
+        snmpEngine, authData, transportTarget, contextData.contextName)
 
     deferred = Deferred()
 
@@ -536,7 +539,8 @@ def bulkCmd(snmpEngine, authData, transportTarget, contextData,
             else:
                 deferred.callback((errorStatus, errorIndex, varBindsUnmade))
 
-    addrName, paramsName = lcd.configure(snmpEngine, authData, transportTarget)
+    addrName, paramsName = lcd.configure(
+        snmpEngine, authData, transportTarget, contextData.contextName)
 
     deferred = Deferred()
 

--- a/pysnmp/hlapi/twisted/ntforg.py
+++ b/pysnmp/hlapi/twisted/ntforg.py
@@ -137,9 +137,8 @@ def sendNotification(snmpEngine, authData, transportTarget, contextData,
             else:
                 deferred.callback((errorStatus, errorIndex, varBindsUnmade))
 
-    notifyName = lcd.configure(
-        snmpEngine, authData, transportTarget, notifyType
-    )
+    notifyName = lcd.configure(snmpEngine, authData, transportTarget,
+                               notifyType, contextData.contextName)
 
     def __trapFun(deferred):
         deferred.callback((0, 0, []))


### PR DESCRIPTION
Fixed hlapi LCD configurator to include `contextName`.
Prior to this fix sending SNMPv3 TRAP with non-default
`contextName` would fail.

This change modifies the signature of the internal
LCD methods.