### PR TITLE
Introduce asyncio binding to hlapi.v1arch

### DIFF
--- a/docs/source/examples/contents.rst
+++ b/docs/source/examples/contents.rst
@@ -83,6 +83,11 @@ The v1 architecture
 
    /examples/hlapi/v1arch/asyncore/contents
 
+.. toctree::
+   :maxdepth: 2
+
+   /examples/hlapi/v1arch/asyncio/contents
+
 Low-level v3 architecture
 -------------------------
 

--- a/docs/source/examples/hlapi/v1arch/asyncio/agent/ntforg/advanced-topics.rst
+++ b/docs/source/examples/hlapi/v1arch/asyncio/agent/ntforg/advanced-topics.rst
@@ -1,0 +1,17 @@
+.. toctree::
+   :maxdepth: 2
+
+Advanced Notification Originator
+--------------------------------
+
+.. include:: /../../examples/hlapi/v1arch/asyncio/agent/ntforg/multiple-notifications-at-once.py
+   :start-after: """
+   :end-before: """#
+
+.. literalinclude:: /../../examples/hlapi/v1arch/asyncio/agent/ntforg/multiple-notifications-at-once.py
+   :start-after: """#
+   :language: python
+
+:download:`Download</../../examples/hlapi/v1arch/asyncio/agent/ntforg/multiple-notifications-at-once.py>` script.
+
+See also: :doc:`library reference </docs/api-reference>`.

--- a/docs/source/examples/hlapi/v1arch/asyncio/agent/ntforg/common-notifications.rst
+++ b/docs/source/examples/hlapi/v1arch/asyncio/agent/ntforg/common-notifications.rst
@@ -1,0 +1,17 @@
+.. toctree::
+   :maxdepth: 2
+
+Common notifications
+--------------------
+
+.. include:: /../../examples/hlapi/v1arch/asyncio/agent/ntforg/default-v1-trap.py
+   :start-after: """
+   :end-before: """#
+
+.. literalinclude:: /../../examples/hlapi/v1arch/asyncio/agent/ntforg/default-v1-trap.py
+   :start-after: """#
+   :language: python
+
+:download:`Download</../../examples/hlapi/v1arch/asyncio/agent/ntforg/default-v1-trap.py>` script.
+
+See also: :doc:`library reference </docs/api-reference>`.

--- a/docs/source/examples/hlapi/v1arch/asyncio/contents.rst
+++ b/docs/source/examples/hlapi/v1arch/asyncio/contents.rst
@@ -1,0 +1,67 @@
+
+Asynchronous SNMP (asynio, v1arch)
+==================================
+
+The :mod:`asyncio` module first appeared in standard library since
+Python 3.3 (in provisional basis). Its main design feature is that it
+makes asynchronous code looking like synchronous one thus eliminating
+"callback hell".
+
+With `asyncio` built-in facilities, you could run many SNMP queries
+in parallel and/or sequentially, interleave SNMP queries with other I/O
+operations. See `asyncio resources <http://asyncio.org>`_
+repository for other `asyncio`-compatible modules.
+
+In most examples approximate analogues of well known Net-SNMP snmp* tools
+command line options are shown. That may help those readers who, by chance
+are familiar with Net-SNMP tools, better understanding what example code doe
+
+Here's a quick example on a simple SNMP GET by high-level API:
+
+.. include:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/v1-get.py
+   :start-after: options:
+   :end-before: Functionally
+
+.. literalinclude:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/v1-get.py
+   :start-after: """#
+   :language: python
+
+The following code performs a series of SNMP GETNEXT operations effectively
+fetching a table of SNMP variables from SNMP Agent:
+
+.. include:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/getbulk-to-eom.py
+   :start-after: options:
+   :end-before: Functionally
+
+.. literalinclude:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/getbulk-to-eom.py
+   :start-after: """#
+   :language: python
+
+More examples on Command Generator API usage follow.
+
+.. toctree::
+
+   /examples/hlapi/v1arch/asyncio/manager/cmdgen/snmp-versions
+   /examples/hlapi/v1arch/asyncio/manager/cmdgen/walking-operations
+   /examples/hlapi/v1arch/asyncio/manager/cmdgen/advanced-topics
+
+Sending SNMP TRAP's and INFORM's is as easy with PySNMP library.
+The following code sends SNMP TRAP:
+
+.. include:: /../../examples/hlapi/v1arch/asyncio/agent/ntforg/default-v1-trap.py
+   :start-after: options:
+   :end-before: Functionally
+
+.. literalinclude:: /../../examples/hlapi/v1arch/asyncio/agent/ntforg/default-v1-trap.py
+   :start-after: """#
+   :language: python
+
+More examples on Notification Originator API usage follow.
+
+.. toctree::
+
+   /examples/hlapi/v1arch/asyncio/agent/ntforg/common-notifications
+   /examples/hlapi/v1arch/asyncio/agent/ntforg/advanced-topics
+
+More sophisticated or less popular SNMP operations can still be performed 
+with PySNMP through its Native API to Standard SNMP Applications.

--- a/docs/source/examples/hlapi/v1arch/asyncio/manager/cmdgen/advanced-topics.rst
+++ b/docs/source/examples/hlapi/v1arch/asyncio/manager/cmdgen/advanced-topics.rst
@@ -1,0 +1,29 @@
+.. toctree::
+   :maxdepth: 2
+
+Advanced Command Generator
+--------------------------
+
+.. include:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/multiple-concurrent-queries-over-ipv4-and-ipv6.py
+   :start-after: """
+   :end-before: """#
+
+.. literalinclude:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/multiple-concurrent-queries-over-ipv4-and-ipv6.py
+   :start-after: """#
+   :language: python
+
+:download:`Download</../../examples/hlapi/v1arch/asyncio/manager/cmdgen/multiple-concurrent-queries-over-ipv4-and-ipv6.py>` script.
+
+
+.. include:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/multiple-sequential-queries.py
+   :start-after: """
+   :end-before: """#
+
+.. literalinclude:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/multiple-sequential-queries.py
+   :start-after: """#
+   :language: python
+
+:download:`Download</../../examples/hlapi/v1arch/asyncio/manager/cmdgen/multiple-sequential-queries.py>` script.
+
+
+See also: :doc:`library reference </docs/api-reference>`.

--- a/docs/source/examples/hlapi/v1arch/asyncio/manager/cmdgen/snmp-versions.rst
+++ b/docs/source/examples/hlapi/v1arch/asyncio/manager/cmdgen/snmp-versions.rst
@@ -1,0 +1,29 @@
+.. toctree::
+   :maxdepth: 2
+
+Various SNMP versions
+----------------------
+
+.. include:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/v1-get.py
+   :start-after: """
+   :end-before: """#
+
+.. literalinclude:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/v1-get.py
+   :start-after: """#
+   :language: python
+
+:download:`Download</../../examples/hlapi/v1arch/asyncio/manager/cmdgen/v1-get.py>` script.
+
+
+.. include:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/getbulk-to-eom.py
+   :start-after: """
+   :end-before: """#
+
+.. literalinclude:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/getbulk-to-eom.py
+   :start-after: """#
+   :language: python
+
+:download:`Download</../../examples/hlapi/v1arch/asyncio/manager/cmdgen/getbulk-to-eom.py>` script.
+
+
+See also: :doc:`library reference </docs/api-reference>`.

--- a/docs/source/examples/hlapi/v1arch/asyncio/manager/cmdgen/walking-operations.rst
+++ b/docs/source/examples/hlapi/v1arch/asyncio/manager/cmdgen/walking-operations.rst
@@ -1,0 +1,17 @@
+.. toctree::
+   :maxdepth: 2
+
+Walking operations
+------------------
+
+.. include:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/getbulk-to-eom.py
+   :start-after: """
+   :end-before: """#
+
+.. literalinclude:: /../../examples/hlapi/v1arch/asyncio/manager/cmdgen/getbulk-to-eom.py
+   :start-after: """#
+   :language: python
+
+:download:`Download</../../examples/hlapi/v1arch/asyncio/manager/cmdgen/getbulk-to-eom.py>` script.
+
+See also: :doc:`library reference </docs/api-reference>`.

--- a/examples/hlapi/v1arch/asyncio/agent/ntforg/default-v1-trap.py
+++ b/examples/hlapi/v1arch/asyncio/agent/ntforg/default-v1-trap.py
@@ -1,0 +1,55 @@
+"""
+SNMPv1 TRAP with defaults
++++++++++++++++++++++++++
+
+Send SNMPv1 TRAP using the following options:
+
+* SNMPv1
+* with community name 'public'
+* over IPv4/UDP
+* send TRAP notification
+* with Generic Trap #1 (warmStart) and Specific Trap 0
+* with default Uptime
+* with default Agent Address
+* with Enterprise OID 1.3.6.1.4.1.20408.4.1.1.2
+* include managed object information '1.3.6.1.2.1.1.1.0' = 'my system'
+
+Functionally similar to:
+
+| $ snmptrap -v1 -c public demo.snmplabs.com 1.3.6.1.4.1.20408.4.1.1.2 0.0.0.0 \
+        1 0 0 1.3.6.1.2.1.1.1.0 s "my system"
+
+"""#
+import asyncio
+from pysnmp.hlapi.v1arch.asyncio import *
+
+
+@asyncio.coroutine
+def run():
+
+    snmpDispatcher = SnmpDispatcher()
+
+    iterator = sendNotification(
+        snmpDispatcher,
+        CommunityData('public', mpModel=0),
+        UdpTransportTarget(('demo.snmplabs.com', 162)),
+        'trap',
+        NotificationType(
+            ObjectIdentity('1.3.6.1.6.3.1.1.5.2')
+        ).loadMibs(
+            'SNMPv2-MIB'
+        ).addVarBinds(
+            ('1.3.6.1.6.3.1.1.4.3.0', '1.3.6.1.4.1.20408.4.1.1.2'),
+            ('1.3.6.1.2.1.1.1.0', OctetString('my system'))
+        )
+    )
+
+    errorIndication, errorStatus, errorIndex, varBinds = yield from iterator
+
+    if errorIndication:
+        print(errorIndication)
+
+    snmpDispatcher.transportDispatcher.closeDispatcher()
+
+
+asyncio.get_event_loop().run_until_complete(run())

--- a/examples/hlapi/v1arch/asyncio/agent/ntforg/multiple-notifications-at-once.py
+++ b/examples/hlapi/v1arch/asyncio/agent/ntforg/multiple-notifications-at-once.py
@@ -1,0 +1,59 @@
+"""
+Multiple concurrent notifications
++++++++++++++++++++++++++++++++++
+
+Send multiple SNMP notifications at once using the following options:
+
+* SNMPv2c
+* with community name 'public'
+* over IPv4/UDP
+* send INFORM notification
+* to multiple Managers
+* with TRAP ID 'coldStart' specified as a MIB symbol
+
+Functionally similar to:
+
+| $ snmptrap -v2c -c public demo.snmplabs.com 12345 1.3.6.1.6.3.1.1.5.2
+| $ snmpinform -v2c -c public demo.snmplabs.com 12345 1.3.6.1.6.3.1.1.5.2
+
+"""#
+import asyncio
+from pysnmp.hlapi.v1arch.asyncio import *
+
+
+@asyncio.coroutine
+def sendone(snmpDispatcher, hostname, notifyType):
+
+    iterator = sendNotification(
+        snmpDispatcher,
+        CommunityData('public'),
+        UdpTransportTarget((hostname, 162)),
+        notifyType,
+        NotificationType(
+            ObjectIdentity('1.3.6.1.6.3.1.1.5.2')
+        ).loadMibs('SNMPv2-MIB')
+    )
+
+    errorIndication, errorStatus, errorIndex, varBinds = yield from iterator
+
+    if errorIndication:
+        print(errorIndication)
+
+    elif errorStatus:
+        print('%s: at %s' % (errorStatus.prettyPrint(), errorIndex and
+                             varBinds[int(errorIndex) - 1][0] or '?'))
+
+    else:
+        for varBind in varBinds:
+            print(' = '.join([x.prettyPrint() for x in varBind]))
+
+
+snmpDispatcher = SnmpDispatcher()
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(
+    asyncio.wait(
+        [sendone(snmpDispatcher, 'demo.snmplabs.com', 'trap'),
+         sendone(snmpDispatcher, 'demo.snmplabs.com', 'inform')]
+    )
+)

--- a/examples/hlapi/v1arch/asyncio/manager/cmdgen/getbulk-to-eom.py
+++ b/examples/hlapi/v1arch/asyncio/manager/cmdgen/getbulk-to-eom.py
@@ -1,0 +1,65 @@
+"""
+Bulk walk MIB
++++++++++++++
+
+Send a series of SNMP GETBULK requests using the following options:
+
+* with SNMPv2c, community 'public'
+* over IPv4/UDP
+* to an Agent at demo.snmplabs.com:161
+* for all OIDs past SNMPv2-MIB::system
+* run till end-of-mib condition is reported by Agent
+* based on asyncio I/O framework
+
+Functionally similar to:
+
+| $ snmpbulkwalk -v2c -c public -Cn0 -Cr50 \
+|                demo.snmplabs.com  SNMPv2-MIB::system
+
+"""#
+import asyncio
+from pysnmp.hlapi.v1arch.asyncio import *
+
+
+@asyncio.coroutine
+def run(varBinds):
+
+    snmpDispatcher = SnmpDispatcher()
+
+    while True:
+        iterator = bulkCmd(
+            snmpDispatcher,
+            CommunityData('public'),
+            UdpTransportTarget(('demo.snmplabs.com', 161)),
+            0, 50,
+            *varBinds
+        )
+
+        errorIndication, errorStatus, errorIndex, varBindTable = yield from iterator
+
+        if errorIndication:
+            print(errorIndication)
+            break
+
+        elif errorStatus:
+            print('%s at %s' % (
+                errorStatus.prettyPrint(),
+                errorIndex and varBinds[int(errorIndex) - 1][0] or '?'
+            )
+                  )
+        else:
+            for varBindRow in varBindTable:
+                for varBind in varBindRow:
+                    print(' = '.join([x.prettyPrint() for x in varBind]))
+
+        varBinds = varBindTable[-1]
+        if isEndOfMib(varBinds):
+            break
+
+    snmpDispatcher.transportDispatcher.closeDispatcher()
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(
+    run([ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr'))])
+)

--- a/examples/hlapi/v1arch/asyncio/manager/cmdgen/multiple-concurrent-queries-over-ipv4-and-ipv6.py
+++ b/examples/hlapi/v1arch/asyncio/manager/cmdgen/multiple-concurrent-queries-over-ipv4-and-ipv6.py
@@ -1,0 +1,59 @@
+"""
+Concurrent queries
+++++++++++++++++++
+
+Send multiple SNMP GET requests at once using the following options:
+
+* with SNMPv2c, community 'public'
+* over IPv4/UDP
+* to multiple Agents at demo.snmplabs.com
+* for instance of SNMPv2-MIB::sysDescr.0 MIB object
+* based on asyncio I/O framework
+
+Functionally similar to:
+
+| $ snmpget -v2c -c public demo.snmplabs.com:1161 SNMPv2-MIB::sysDescr.0
+| $ snmpget -v2c -c public demo.snmplabs.com:2161 SNMPv2-MIB::sysDescr.0
+| $ snmpget -v2c -c public demo.snmplabs.com:3161 SNMPv2-MIB::sysDescr.0
+
+"""#
+import asyncio
+from pysnmp.hlapi.v1arch.asyncio import *
+
+
+@asyncio.coroutine
+def getone(snmpDispatcher, hostname):
+
+    iterator = getCmd(
+        snmpDispatcher,
+        CommunityData('public'),
+        UdpTransportTarget(hostname),
+        ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr', 0))
+    )
+
+    errorIndication, errorStatus, errorIndex, varBinds = yield from iterator
+
+    if errorIndication:
+        print(errorIndication)
+
+    elif errorStatus:
+        print('%s at %s' % (
+            errorStatus.prettyPrint(),
+            errorIndex and varBinds[int(errorIndex) - 1][0] or '?'
+        )
+              )
+    else:
+        for varBind in varBinds:
+            print(' = '.join([x.prettyPrint() for x in varBind]))
+
+
+snmpDispatcher = SnmpDispatcher()
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(
+    asyncio.wait(
+        [getone(snmpDispatcher, ('demo.snmplabs.com', 1161)),
+         getone(snmpDispatcher, ('demo.snmplabs.com', 2161)),
+         getone(snmpDispatcher, ('demo.snmplabs.com', 3161))]
+    )
+)

--- a/examples/hlapi/v1arch/asyncio/manager/cmdgen/multiple-sequential-queries.py
+++ b/examples/hlapi/v1arch/asyncio/manager/cmdgen/multiple-sequential-queries.py
@@ -1,0 +1,68 @@
+"""
+Sequential queries
+++++++++++++++++++
+
+Send multiple SNMP GET requests one by one using the following options:
+
+* with SNMPv2c, community 'public'
+* over IPv4/UDP
+* to multiple Agents at demo.snmplabs.com
+* for instance of SNMPv2-MIB::sysDescr.0 MIB object
+* based on asyncio I/O framework
+
+Functionally similar to:
+
+| $ snmpget -v2c -c public demo.snmplabs.com:1161 SNMPv2-MIB::sysDescr.0
+| $ snmpget -v2c -c public demo.snmplabs.com:2161 SNMPv2-MIB::sysDescr.0
+| $ snmpget -v2c -c public demo.snmplabs.com:3161 SNMPv2-MIB::sysDescr.0
+
+"""#
+import asyncio
+from pysnmp.hlapi.v1arch.asyncio import *
+
+
+@asyncio.coroutine
+def getone(snmpDispatcher, hostname):
+
+    iterator = getCmd(
+        snmpDispatcher,
+        CommunityData('public'),
+        UdpTransportTarget(hostname),
+        ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr', 0))
+    )
+
+    errorIndication, errorStatus, errorIndex, varBinds = yield from iterator
+
+    if errorIndication:
+        print(errorIndication)
+
+    elif errorStatus:
+        print('%s at %s' % (
+            errorStatus.prettyPrint(),
+            errorIndex and varBinds[int(errorIndex) - 1][0] or '?'
+        )
+              )
+    else:
+        for varBind in varBinds:
+            print(' = '.join([x.prettyPrint() for x in varBind]))
+
+
+@asyncio.coroutine
+def getall(snmpDispatcher, hostnames):
+    for hostname in hostnames:
+        yield from getone(snmpDispatcher, hostname)
+
+
+snmpDispatcher = SnmpDispatcher()
+
+loop = asyncio.get_event_loop()
+
+loop.run_until_complete(
+    getall(
+        snmpDispatcher, [
+            ('demo.snmplabs.com', 1161),
+            ('demo.snmplabs.com', 2161),
+            ('demo.snmplabs.com', 3161)
+        ]
+    )
+)

--- a/examples/hlapi/v1arch/asyncio/manager/cmdgen/v1-get.py
+++ b/examples/hlapi/v1arch/asyncio/manager/cmdgen/v1-get.py
@@ -1,0 +1,51 @@
+"""
+SNMPv1
+++++++
+
+Send SNMP GET request using the following options:
+
+  * with SNMPv1, community 'public'
+  * over IPv4/UDP
+  * to an Agent at demo.snmplabs.com:161
+  * for the 1.3.6.1.2.1.1.1.0 OID (e.g. SNMPv2-MIB::sysDescr.0 MIB object)
+  * Based on asyncio I/O framework
+
+Functionally similar to:
+
+| $ snmpget -v1 -c public demo.snmplabs.com SNMPv2-MIB::sysDescr.0
+
+"""#
+import asyncio
+from pysnmp.hlapi.v1arch.asyncio import *
+
+
+@asyncio.coroutine
+def run():
+    snmpDispatcher = SnmpDispatcher()
+
+    iterator = getCmd(
+        snmpDispatcher,
+        CommunityData('public', mpModel=0),
+        UdpTransportTarget(('demo.snmplabs.com', 161)),
+        ('1.3.6.1.2.1.1.1.0', None)
+    )
+
+    errorIndication, errorStatus, errorIndex, varBinds = yield from iterator
+
+    if errorIndication:
+        print(errorIndication)
+
+    elif errorStatus:
+        print('%s at %s' % (
+            errorStatus.prettyPrint(),
+            errorIndex and varBinds[int(errorIndex) - 1][0] or '?'
+        )
+              )
+    else:
+        for varBind in varBinds:
+            print(' = '.join([x.prettyPrint() for x in varBind]))
+
+    snmpDispatcher.transportDispatcher.closeDispatcher()
+
+
+asyncio.get_event_loop().run_until_complete(run())

--- a/pysnmp/hlapi/v1arch/asyncio/__init__.py
+++ b/pysnmp/hlapi/v1arch/asyncio/__init__.py
@@ -1,0 +1,13 @@
+#
+# This file is part of pysnmp software.
+#
+# Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>
+# License: http://snmplabs.com/pysnmp/license.html
+#
+from pysnmp.hlapi.v1arch.auth import *
+from pysnmp.hlapi.v1arch.asyncio.transport import *
+from pysnmp.hlapi.v1arch.asyncio.cmdgen import *
+from pysnmp.hlapi.v1arch.asyncio.ntforg import *
+from pysnmp.hlapi.v1arch.asyncio.dispatch import *
+from pysnmp.proto.rfc1902 import *
+from pysnmp.smi.rfc1902 import *

--- a/pysnmp/hlapi/v1arch/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/v1arch/asyncio/cmdgen.py
@@ -1,0 +1,567 @@
+#
+# This file is part of pysnmp software.
+#
+# Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>
+# License: http://snmplabs.com/pysnmp/license.html
+#
+from pysnmp.hlapi.v1arch.auth import *
+from pysnmp.hlapi.varbinds import *
+from pysnmp.hlapi.v1arch.asyncio.transport import *
+from pysnmp.smi.rfc1902 import *
+from pysnmp.proto import api
+
+try:
+    import asyncio
+
+except ImportError:
+    import trollius as asyncio
+
+__all__ = ['getCmd', 'nextCmd', 'setCmd', 'bulkCmd', 'isEndOfMib']
+
+VB_PROCESSOR = CommandGeneratorVarBinds()
+
+isEndOfMib = lambda varBinds: not api.v2c.apiPDU.getNextVarBinds(varBinds)[1]
+
+
+@asyncio.coroutine
+def getCmd(snmpDispatcher, authData, transportTarget,
+           *varBinds, **options):
+    """Creates a generator to perform SNMP GET query.
+
+    When iterator gets advanced by :py:mod:`asyncio` main loop,
+    SNMP GET request is sent (:RFC:`1905#section-4.2.1`).
+    The iterator yields :py:class:`asyncio.Future` which gets done whenever
+    response arrives or error occurs.
+
+    Parameters
+    ----------
+    snmpDispatcher: :py:class:`~pysnmp.hlapi.v1arch.asyncore.SnmpDispatcher`
+        Class instance representing asynio-based asynchronous event loop and
+        associated state information.
+
+    authData: :py:class:`~pysnmp.hlapi.v1arch.CommunityData`
+        Class instance representing SNMPv1/v2c credentials.
+
+    transportTarget: :py:class:`~pysnmp.hlapi.v1arch.asyncio.UdpTransportTarget` or
+        :py:class:`~pysnmp.hlapi.v1arch.asyncio.Udp6TransportTarget` Class instance representing
+        transport type along with SNMP peer address.
+
+    \*varBinds: :class:`tuple` of OID-value pairs or :py:class:`~pysnmp.smi.rfc1902.ObjectType`
+        One or more class instances representing MIB variables to place
+        into SNMP request.
+
+    Note
+    ----
+    The `SnmpDispatcher` object may be expensive to create, therefore it is
+    advised to maintain it for the lifecycle of the application/thread for
+    as long as possible.
+
+    Other Parameters
+    ----------------
+    \*\*options :
+        Request options:
+
+        * `lookupMib` - load MIB and resolve response MIB variables at
+          the cost of slightly reduced performance. Default is `False`,
+          unless :py:class:`~pysnmp.smi.rfc1902.ObjectType` is present
+          among `varBinds` in which case `lookupMib` gets automatically
+          enabled.
+
+    Yields
+    ------
+    errorIndication: str
+        True value indicates SNMP engine error.
+    errorStatus: str
+        True value indicates SNMP PDU error.
+    errorIndex: int
+        Non-zero value refers to `varBinds[errorIndex-1]`
+    varBinds: tuple
+        A sequence of OID-value pairs in form of base SNMP types (if
+        `lookupMib` is `False`) or :py:class:`~pysnmp.smi.rfc1902.ObjectType`
+        class instances (if `lookupMib` is `True`) representing MIB variables
+        returned in SNMP response.
+
+    Raises
+    ------
+    PySnmpError
+        Or its derivative indicating that an error occurred while
+        performing SNMP operation.
+
+    Examples
+    --------
+    >>> import asyncio
+    >>> from pysnmp.hlapi.v1arch.asyncio import *
+    >>>
+    >>> @asyncio.coroutine
+    ... def run():
+    ...     errorIndication, errorStatus, errorIndex, varBinds = yield from getCmd(
+    ...         SnmpDispatcher(),
+    ...         CommunityData('public'),
+    ...         UdpTransportTarget(('demo.snmplabs.com', 161)),
+    ...         ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr', 0))
+    ...     )
+    ...     print(errorIndication, errorStatus, errorIndex, varBinds)
+    >>>
+    >>> asyncio.get_event_loop().run_until_complete(run())
+    (None, 0, 0, [ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.1.0')), DisplayString('SunOS zeus.snmplabs.com 4.1.3_U1 1 sun4m'))])
+    >>>
+    """
+
+    def _cbFun(snmpDispatcher, stateHandle, errorIndication, rspPdu, _cbCtx):
+        if future.cancelled():
+            return
+
+        errorStatus = pMod.apiPDU.getErrorStatus(rspPdu)
+        errorIndex = pMod.apiPDU.getErrorIndex(rspPdu)
+
+        varBinds = pMod.apiPDU.getVarBinds(rspPdu)
+
+        if lookupMib:
+            try:
+                varBinds = VB_PROCESSOR.unmakeVarBinds(
+                    snmpDispatcher.cache, varBinds, lookupMib)
+
+            except Exception as e:
+                future.set_exception(e)
+                return
+
+        future.set_result(
+            (errorIndication, errorStatus, errorIndex, varBinds)
+        )
+
+    lookupMib = options.get('lookupMib')
+
+    if not lookupMib and any(isinstance(x, ObjectType) for x in varBinds):
+        lookupMib = True
+
+    if lookupMib:
+        varBinds = VB_PROCESSOR.makeVarBinds(snmpDispatcher.cache, varBinds)
+
+    pMod = api.PROTOCOL_MODULES[authData.mpModel]
+
+    reqPdu = pMod.GetRequestPDU()
+    pMod.apiPDU.setDefaults(reqPdu)
+    pMod.apiPDU.setVarBinds(reqPdu, varBinds)
+
+    future = asyncio.Future()
+
+    snmpDispatcher.sendPdu(authData, transportTarget, reqPdu, cbFun=_cbFun)
+
+    return future
+
+
+@asyncio.coroutine
+def setCmd(snmpDispatcher, authData, transportTarget,
+           *varBinds, **options):
+    """Creates a generator to perform SNMP SET query.
+
+    When iterator gets advanced by :py:mod:`asyncio` main loop,
+    SNMP SET request is sent (:RFC:`1905#section-4.2.5`).
+    The iterator yields :py:class:`asyncio.Future` which gets done whenever
+    response arrives or error occurs.
+
+    Parameters
+    ----------
+    snmpDispatcher: :py:class:`~pysnmp.hlapi.v1arch.asyncore.SnmpDispatcher`
+        Class instance representing asynio-based asynchronous event loop and
+        associated state information.
+
+    authData: :py:class:`~pysnmp.hlapi.v1arch.CommunityData`
+        Class instance representing SNMPv1/v2c credentials.
+
+    transportTarget: :py:class:`~pysnmp.hlapi.v1arch.asyncio.UdpTransportTarget` or
+        :py:class:`~pysnmp.hlapi.v1arch.asyncio.Udp6TransportTarget` Class instance representing
+        transport type along with SNMP peer address.
+
+    \*varBinds: :class:`tuple` of OID-value pairs or :py:class:`~pysnmp.smi.rfc1902.ObjectType`
+        One or more class instances representing MIB variables to place
+        into SNMP request.
+
+    Note
+    ----
+    The `SnmpDispatcher` object may be expensive to create, therefore it is
+    advised to maintain it for the lifecycle of the application/thread for
+    as long as possible.
+
+    Other Parameters
+    ----------------
+    \*\*options :
+        Request options:
+
+        * `lookupMib` - load MIB and resolve response MIB variables at
+          the cost of slightly reduced performance. Default is `False`,
+          unless :py:class:`~pysnmp.smi.rfc1902.ObjectType` is present
+          among `varBinds` in which case `lookupMib` gets automatically
+          enabled.
+
+    Yields
+    ------
+    errorIndication: str
+        True value indicates SNMP engine error.
+    errorStatus: str
+        True value indicates SNMP PDU error.
+    errorIndex: int
+        Non-zero value refers to `varBinds[errorIndex-1]`
+    varBinds: tuple
+        A sequence of OID-value pairs in form of base SNMP types (if
+        `lookupMib` is `False`) or :py:class:`~pysnmp.smi.rfc1902.ObjectType`
+        class instances (if `lookupMib` is `True`) representing MIB variables
+        returned in SNMP response.
+
+    Raises
+    ------
+    PySnmpError
+        Or its derivative indicating that an error occurred while
+        performing SNMP operation.
+
+    Examples
+    --------
+    >>> import asyncio
+    >>> from pysnmp.hlapi.v1arch.asyncio import *
+    >>>
+    >>> @asyncio.coroutine
+    ... def run():
+    ...     errorIndication, errorStatus, errorIndex, varBinds = yield from setCmd(
+    ...         SnmpDispatcher(),
+    ...         CommunityData('public'),
+    ...         UdpTransportTarget(('demo.snmplabs.com', 161)),
+    ...         ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr', 0), 'Linux i386')
+    ...     )
+    ...     print(errorIndication, errorStatus, errorIndex, varBinds)
+    >>>
+    >>> asyncio.get_event_loop().run_until_complete(run())
+    (None, 0, 0, [ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.1.0')), DisplayString('Linux i386'))])
+    >>>
+    """
+
+    def _cbFun(snmpDispatcher, stateHandle, errorIndication, rspPdu, _cbCtx):
+        if future.cancelled():
+            return
+
+        errorStatus = pMod.apiPDU.getErrorStatus(rspPdu)
+        errorIndex = pMod.apiPDU.getErrorIndex(rspPdu)
+
+        varBinds = pMod.apiPDU.getVarBinds(rspPdu)
+
+        if lookupMib:
+            try:
+                varBinds = VB_PROCESSOR.unmakeVarBinds(
+                    snmpDispatcher.cache, varBinds, lookupMib)
+
+            except Exception as e:
+                future.set_exception(e)
+                return
+
+        future.set_result(
+            (errorIndication, errorStatus, errorIndex, varBinds)
+        )
+
+    lookupMib = options.get('lookupMib')
+
+    if not lookupMib and any(isinstance(x, ObjectType) for x in varBinds):
+        lookupMib = True
+
+    if lookupMib:
+        varBinds = VB_PROCESSOR.makeVarBinds(snmpDispatcher.cache, varBinds)
+
+    pMod = api.PROTOCOL_MODULES[authData.mpModel]
+
+    reqPdu = pMod.SetRequestPDU()
+    pMod.apiPDU.setDefaults(reqPdu)
+    pMod.apiPDU.setVarBinds(reqPdu, varBinds)
+
+    future = asyncio.Future()
+
+    snmpDispatcher.sendPdu(authData, transportTarget, reqPdu, cbFun=_cbFun)
+
+    return future
+
+
+@asyncio.coroutine
+def nextCmd(snmpDispatcher, authData, transportTarget,
+            *varBinds, **options):
+    """Creates a generator to perform SNMP GETNEXT query.
+
+    When iterator gets advanced by :py:mod:`asyncio` main loop,
+    SNMP GETNEXT request is send (:RFC:`1905#section-4.2.2`).
+    The iterator yields :py:class:`asyncio.Future` which gets done whenever
+    response arrives or error occurs.
+
+    Parameters
+    ----------
+    snmpDispatcher: :py:class:`~pysnmp.hlapi.v1arch.asyncore.SnmpDispatcher`
+        Class instance representing asynio-based asynchronous event loop and
+        associated state information.
+
+    authData: :py:class:`~pysnmp.hlapi.v1arch.CommunityData`
+        Class instance representing SNMPv1/v2c credentials.
+
+    transportTarget: :py:class:`~pysnmp.hlapi.v1arch.asyncio.UdpTransportTarget` or
+        :py:class:`~pysnmp.hlapi.v1arch.asyncio.Udp6TransportTarget` Class instance representing
+        transport type along with SNMP peer address.
+
+    \*varBinds: :class:`tuple` of OID-value pairs or :py:class:`~pysnmp.smi.rfc1902.ObjectType`
+        One or more class instances representing MIB variables to place
+        into SNMP request.
+
+    Note
+    ----
+    The `SnmpDispatcher` object may be expensive to create, therefore it is
+    advised to maintain it for the lifecycle of the application/thread for
+    as long as possible.
+
+    Other Parameters
+    ----------------
+    \*\*options:
+        Request options:
+
+        * `lookupMib` - load MIB and resolve response MIB variables at
+          the cost of slightly reduced performance. Default is `False`,
+          unless :py:class:`~pysnmp.smi.rfc1902.ObjectType` is present
+          among `varBinds` in which case `lookupMib` gets automatically
+          enabled.
+
+    Yields
+    ------
+    errorIndication: str
+        True value indicates SNMP engine error.
+    errorStatus: str
+        True value indicates SNMP PDU error.
+    errorIndex: int
+        Non-zero value refers to `varBinds[errorIndex-1]`
+    varBinds: tuple
+        A sequence of sequences (e.g. 2-D array) of OID-value pairs in form
+        of base SNMP types (if `lookupMib` is `False`) or
+        :py:class:`~pysnmp.smi.rfc1902.ObjectType` class instances (if
+        `lookupMib` is `True`) a table of MIB variables returned in SNMP
+        response. Inner sequences represent table rows and ordered exactly
+        the same as `varBinds` in request. Response to GETNEXT always contain
+        a single row.
+
+    Raises
+    ------
+    PySnmpError
+        Or its derivative indicating that an error occurred while
+        performing SNMP operation.
+
+    Examples
+    --------
+    >>> import asyncio
+    >>> from pysnmp.hlapi.asyncio import *
+    >>>
+    >>> @asyncio.coroutine
+    ... def run():
+    ...     errorIndication, errorStatus, errorIndex, varBinds = yield from nextCmd(
+    ...         SnmpDispatcher(),
+    ...         CommunityData('public'),
+    ...         UdpTransportTarget(('demo.snmplabs.com', 161)),
+    ...         ContextData(),
+    ...         ObjectType(ObjectIdentity('SNMPv2-MIB', 'system'))
+    ...     )
+    ...     print(errorIndication, errorStatus, errorIndex, varBinds)
+    >>>
+    >>> asyncio.get_event_loop().run_until_complete(run())
+    (None, 0, 0, [[ObjectType(ObjectIdentity('1.3.6.1.2.1.1.1.0'), DisplayString('Linux i386'))]])
+    >>>
+    """
+    def _cbFun(snmpDispatcher, stateHandle, errorIndication, rspPdu, _cbCtx):
+        if future.cancelled():
+            return
+
+        errorStatus = pMod.apiPDU.getErrorStatus(rspPdu)
+        errorIndex = pMod.apiPDU.getErrorIndex(rspPdu)
+
+        varBindTable = pMod.apiPDU.getVarBindTable(reqPdu, rspPdu)
+
+        if lookupMib:
+            try:
+                varBindTable = [
+                    VB_PROCESSOR.unmakeVarBinds(snmpDispatcher.cache,
+                                                varBindTableRow, lookupMib)
+                    for varBindTableRow in varBindTable
+                ]
+
+            except Exception as e:
+                future.set_exception(e)
+                return
+
+        future.set_result(
+            (errorIndication, errorStatus, errorIndex, varBindTable)
+        )
+
+    lookupMib = options.get('lookupMib')
+
+    if not lookupMib and any(isinstance(x, ObjectType) for x in varBinds):
+        lookupMib = True
+
+    if lookupMib:
+        varBinds = VB_PROCESSOR.makeVarBinds(snmpDispatcher.cache, varBinds)
+
+    pMod = api.PROTOCOL_MODULES[authData.mpModel]
+
+    reqPdu = pMod.GetNextRequestPDU()
+    pMod.apiPDU.setDefaults(reqPdu)
+    pMod.apiPDU.setVarBinds(reqPdu, varBinds)
+
+    future = asyncio.Future()
+
+    snmpDispatcher.sendPdu(authData, transportTarget, reqPdu, cbFun=_cbFun)
+
+    return future
+
+
+@asyncio.coroutine
+def bulkCmd(snmpDispatcher, authData, transportTarget,
+            nonRepeaters, maxRepetitions, *varBinds, **options):
+    """Creates a generator to perform SNMP GETBULK query.
+
+    When iterator gets advanced by :py:mod:`asyncio` main loop,
+    SNMP GETBULK request is send (:RFC:`1905#section-4.2.3`).
+    The iterator yields :py:class:`asyncio.Future` which gets done whenever
+    response arrives or error occurs.
+
+    Parameters
+    ----------
+    snmpDispatcher: :py:class:`~pysnmp.hlapi.v1arch.asyncore.SnmpDispatcher`
+        Class instance representing asynio-based asynchronous event loop and
+        associated state information.
+
+    authData: :py:class:`~pysnmp.hlapi.v1arch.CommunityData`
+        Class instance representing SNMPv1/v2c credentials.
+
+    transportTarget: :py:class:`~pysnmp.hlapi.v1arch.asyncio.UdpTransportTarget` or
+        :py:class:`~pysnmp.hlapi.v1arch.asyncio.Udp6TransportTarget` Class instance representing
+        transport type along with SNMP peer address.
+
+    nonRepeaters : int
+        One MIB variable is requested in response for the first
+        `nonRepeaters` MIB variables in request.
+
+    maxRepetitions : int
+        `maxRepetitions` MIB variables are requested in response for each
+        of the remaining MIB variables in the request (e.g. excluding
+        `nonRepeaters`). Remote SNMP engine may choose lesser value than
+        requested.
+
+    \*varBinds: :class:`tuple` of OID-value pairs or :py:class:`~pysnmp.smi.rfc1902.ObjectType`
+        One or more class instances representing MIB variables to place
+        into SNMP request.
+
+    Other Parameters
+    ----------------
+    \*\*options :
+        Request options:
+
+        * `lookupMib` - load MIB and resolve response MIB variables at
+          the cost of slightly reduced performance. Default is `False`,
+          unless :py:class:`~pysnmp.smi.rfc1902.ObjectType` is present
+          among `varBinds` in which case `lookupMib` gets automatically
+          enabled.
+
+    Yields
+    ------
+    errorIndication: str
+        True value indicates SNMP engine error.
+    errorStatus: str
+        True value indicates SNMP PDU error.
+    errorIndex: int
+        Non-zero value refers to `varBinds[errorIndex-1]`
+    varBindTable: tuple
+        A sequence of sequences (e.g. 2-D array) of OID-value pairs in form
+        of base SNMP types (if `lookupMib` is `False`) or
+        :py:class:`~pysnmp.smi.rfc1902.ObjectType` class instances (if
+        `lookupMib` is `True`) a table of MIB variables returned in SNMP
+        response, with up to `maxRepetitions` rows, i.e.
+        `len(varBindTable) <= maxRepetitions`.
+
+        For `0 <= i < len(varBindTable)` and `0 <= j < len(varBinds)`,
+        `varBindTable[i][j]` represents:
+
+        - For non-repeaters (`j < nonRepeaters`), the first lexicographic
+          successor of `varBinds[j]`, regardless the value of `i`, or an
+          :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
+          :py:obj:`~pysnmp.proto.rfc1905.endOfMibView` value if no such
+          successor exists;
+        - For repeaters (`j >= nonRepeaters`), the `i`-th lexicographic
+          successor of `varBinds[j]`, or an
+          :py:class:`~pysnmp.smi.rfc1902.ObjectType` instance with the
+          :py:obj:`~pysnmp.proto.rfc1905.endOfMibView` value if no such
+          successor exists.
+
+        See :rfc:`3416#section-4.2.3` for details on the underlying
+        `GetBulkRequest-PDU` and the associated `GetResponse-PDU`, such as
+        specific conditions under which the server may truncate the response,
+        causing `varBindTable` to have less than `maxRepetitions` rows.
+
+    Raises
+    ------
+    PySnmpError
+        Or its derivative indicating that an error occurred while
+        performing SNMP operation.
+
+    Examples
+    --------
+    >>> import asyncio
+    >>> from pysnmp.hlapi.v1arch.asyncio import *
+    >>>
+    >>> @asyncio.coroutine
+    ... def run():
+    ...     errorIndication, errorStatus, errorIndex, varBinds = yield from bulkCmd(
+    ...         SnmpDispatcher(),
+    ...         CommunityData('public'),
+    ...         UdpTransportTarget(('demo.snmplabs.com', 161)),
+    ...         0, 2,
+    ...         ObjectType(ObjectIdentity('SNMPv2-MIB', 'system'))
+    ...     )
+    ...     print(errorIndication, errorStatus, errorIndex, varBinds)
+    >>>
+    >>> asyncio.get_event_loop().run_until_complete(run())
+    (None, 0, 0, [[ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.1.0')), DisplayString('SunOS zeus.snmplabs.com 4.1.3_U1 1 sun4m'))], [ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.2.0')), ObjectIdentifier('1.3.6.1.4.1.424242.1.1'))]])
+    >>>
+    """
+    def _cbFun(snmpDispatcher, stateHandle, errorIndication, rspPdu, _cbCtx):
+        if future.cancelled():
+            return
+
+        errorStatus = pMod.apiPDU.getErrorStatus(rspPdu)
+        errorIndex = pMod.apiPDU.getErrorIndex(rspPdu)
+
+        varBindTable = pMod.apiBulkPDU.getVarBindTable(reqPdu, rspPdu)
+
+        if lookupMib:
+            try:
+                varBindTable = [
+                    VB_PROCESSOR.unmakeVarBinds(snmpDispatcher.cache,
+                                                varBindTableRow, lookupMib)
+                    for varBindTableRow in varBindTable
+                ]
+
+            except Exception as e:
+                future.set_exception(e)
+                return
+
+        future.set_result(
+            (errorIndication, errorStatus, errorIndex, varBindTable)
+        )
+
+    lookupMib = options.get('lookupMib')
+
+    if not lookupMib and any(isinstance(x, ObjectType) for x in varBinds):
+        lookupMib = True
+
+    if lookupMib:
+        varBinds = VB_PROCESSOR.makeVarBinds(snmpDispatcher.cache, varBinds)
+
+    pMod = api.PROTOCOL_MODULES[authData.mpModel]
+
+    reqPdu = pMod.GetBulkRequestPDU()
+    pMod.apiPDU.setDefaults(reqPdu)
+    pMod.apiBulkPDU.setNonRepeaters(reqPdu, nonRepeaters)
+    pMod.apiBulkPDU.setMaxRepetitions(reqPdu, maxRepetitions)
+    pMod.apiPDU.setVarBinds(reqPdu, varBinds)
+
+    future = asyncio.Future()
+
+    snmpDispatcher.sendPdu(authData, transportTarget, reqPdu, cbFun=_cbFun)
+
+    return future

--- a/pysnmp/hlapi/v1arch/asyncio/dispatch.py
+++ b/pysnmp/hlapi/v1arch/asyncio/dispatch.py
@@ -1,0 +1,29 @@
+#
+# This file is part of pysnmp software.
+#
+# Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>
+# License: http://snmplabs.com/pysnmp/license.html
+#
+from pysnmp.carrier.asyncio.dispatch import AsyncioDispatcher
+from pysnmp.hlapi.v1arch.dispatch import AbstractSnmpDispatcher
+
+__all__ = ['SnmpDispatcher']
+
+
+class SnmpDispatcher(AbstractSnmpDispatcher):
+    """Creates SNMP message dispatcher object.
+
+    `SnmpDispatcher` object manages send and receives SNMP PDU
+    messages through underlying transport dispatcher and dispatches
+    them to the callers.
+
+    `SnmpDispatcher` is the only stateful object, all `hlapi.v1arch` SNMP
+    operations require an instance of `SnmpDispatcher`. Users do not normally
+    request services directly from `SnmpDispather`, but pass it around to
+    other `hlapi.v1arch` interfaces.
+
+    It is possible to run multiple instances of `SnmpDispatcher` in the
+    application. In a multithreaded environment, each thread that
+    works with SNMP must have its own `SnmpDispatcher` instance.
+    """
+    PROTO_DISPATCHER = AsyncioDispatcher

--- a/pysnmp/hlapi/v1arch/asyncio/ntforg.py
+++ b/pysnmp/hlapi/v1arch/asyncio/ntforg.py
@@ -1,0 +1,199 @@
+#
+# This file is part of pysnmp software.
+#
+# Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>
+# License: http://snmplabs.com/pysnmp/license.html
+#
+from pysnmp.hlapi.v1arch.auth import *
+from pysnmp.hlapi.varbinds import *
+from pysnmp.hlapi.v1arch.asyncio.transport import *
+from pysnmp.smi.rfc1902 import *
+from pysnmp.proto import api
+
+try:
+    import asyncio
+
+except ImportError:
+    import trollius as asyncio
+
+__all__ = ['sendNotification']
+
+VB_PROCESSOR = NotificationOriginatorVarBinds()
+
+
+@asyncio.coroutine
+def sendNotification(snmpDispatcher, authData, transportTarget,
+                     notifyType, *varBinds, **options):
+    """Creates a generator to send SNMP notification.
+
+    When iterator gets advanced by :py:mod:`asyncio` main loop,
+    SNMP TRAP or INFORM notification is send (:RFC:`1905#section-4.2.6`).
+    The iterator yields :py:class:`asyncio.Future` which gets done whenever
+    response arrives or error occurs.
+
+    Parameters
+    ----------
+    snmpDispatcher: :py:class:`~pysnmp.hlapi.v1arch.asyncore.SnmpDispatcher`
+        Class instance representing asynio-based asynchronous event loop and
+        associated state information.
+
+    authData: :py:class:`~pysnmp.hlapi.v1arch.CommunityData`
+        Class instance representing SNMPv1/v2c credentials.
+
+    transportTarget: :py:class:`~pysnmp.hlapi.v1arch.asyncio.UdpTransportTarget` or
+        :py:class:`~pysnmp.hlapi.v1arch.asyncio.Udp6TransportTarget` Class instance representing
+        transport type along with SNMP peer address.
+
+    notifyType : str
+        Indicates type of notification to be sent. Recognized literal
+        values are *trap* or *inform*.
+
+    \*varBinds: :class:`tuple` of OID-value pairs or :py:class:`~pysnmp.smi.rfc1902.ObjectType` or :py:class:`~pysnmp.smi.rfc1902.NotificationType`
+        One or more objects representing MIB variables to place
+        into SNMP notification. It could be tuples of OID-values
+        or :py:class:`~pysnmp.smi.rfc1902.ObjectType` class instances
+        of :py:class:`~pysnmp.smi.rfc1902.NotificationType` objects.
+
+        SNMP Notification PDU places rigid requirement on the ordering of
+        the variable-bindings.
+
+        Mandatory variable-bindings:
+
+        0. SNMPv2-MIB::sysUpTime.0 = <agent uptime>
+        1. SNMPv2-SMI::snmpTrapOID.0 = {SNMPv2-MIB::coldStart, ...}
+
+        Optional variable-bindings (applicable to SNMP v1 TRAP):
+
+        2. SNMP-COMMUNITY-MIB::snmpTrapAddress.0 = <agent-IP>
+        3. SNMP-COMMUNITY-MIB::snmpTrapCommunity.0 = <snmp-community-name>
+        4. SNMP-COMMUNITY-MIB::snmpTrapEnterprise.0 = <enterprise-OID>
+
+        Informational variable-bindings:
+
+        * SNMPv2-SMI::NOTIFICATION-TYPE
+        * SNMPv2-SMI::OBJECT-TYPE
+
+    Other Parameters
+    ----------------
+    \*\*options :
+        Request options:
+
+        * `lookupMib` - load MIB and resolve response MIB variables at
+          the cost of slightly reduced performance. Default is `False`,
+          unless :py:class:`~pysnmp.smi.rfc1902.ObjectType` or
+          :py:class:`~pysnmp.smi.rfc1902.NotificationType` is present
+          among `varBinds` in which case `lookupMib` gets automatically
+          enabled.
+
+    Yields
+    ------
+    errorIndication: str
+        True value indicates SNMP engine error.
+    errorStatus: str
+        True value indicates SNMP PDU error.
+    errorIndex: int
+        Non-zero value refers to `varBinds[errorIndex-1]`
+    varBinds: tuple
+        A sequence of OID-value pairs in form of base SNMP types (if
+        `lookupMib` is `False`) or :py:class:`~pysnmp.smi.rfc1902.ObjectType`
+        class instances (if `lookupMib` is `True`) representing MIB variables
+        returned in SNMP response.
+
+    Raises
+    ------
+    PySnmpError
+        Or its derivative indicating that an error occurred while
+        performing SNMP operation.
+
+    Examples
+    --------
+    >>> import asyncio
+    >>> from pysnmp.hlapi.asyncio import *
+    >>>
+    >>> @asyncio.coroutine
+    ... def run():
+    ...     errorIndication, errorStatus, errorIndex, varBinds = yield from sendNotification(
+    ...         SnmpDispatcher(),
+    ...         CommunityData('public'),
+    ...         UdpTransportTarget(('demo.snmplabs.com', 162)),
+    ...         'trap',
+    ...         NotificationType(ObjectIdentity('IF-MIB', 'linkDown')))
+    ...     print(errorIndication, errorStatus, errorIndex, varBinds)
+    ...
+    >>> asyncio.get_event_loop().run_until_complete(run())
+    (None, 0, 0, [])
+    >>>
+    """
+
+    def _cbFun(snmpDispatcher, stateHandle, errorIndication, rspPdu, _cbCtx):
+        if future.cancelled():
+            return
+
+        errorStatus = pMod.apiTrapPDU.getErrorStatus(rspPdu)
+        errorIndex = pMod.apiTrapPDU.getErrorIndex(rspPdu)
+
+        varBinds = pMod.apiTrapPDU.getVarBinds(rspPdu)
+
+        try:
+            varBindsUnmade = VB_PROCESSOR.unmakeVarBinds(snmpDispatcher.cache, varBinds,
+                                                         lookupMib)
+        except Exception as e:
+            future.set_exception(e)
+
+        else:
+            future.set_result(
+                (errorIndication, errorStatus, errorIndex, varBindsUnmade)
+            )
+
+    lookupMib = options.get('lookupMib')
+
+    if not lookupMib and any(isinstance(x, (NotificationType, ObjectType))
+                             for x in varBinds):
+        lookupMib = True
+
+    if lookupMib:
+        varBinds = VB_PROCESSOR.makeVarBinds(snmpDispatcher.cache, varBinds)
+
+    # # make sure required PDU payload is in place
+    # completeVarBinds = []
+    #
+    # # ensure sysUpTime
+    # if len(varBinds) < 1 or varBinds[0][0] != pMod.apiTrapPDU.sysUpTime:
+    #     varBinds.insert(0, (ObjectIdentifier(pMod.apiTrapPDU.sysUpTime), pMod.Integer(0)))
+    #
+    # # ensure sysUpTime
+    # if len(varBinds) < 1 or varBinds[0][0] != pMod.apiTrapPDU.sysUpTime:
+    #     varBinds.insert(0, (ObjectIdentifier(pMod.apiTrapPDU.sysUpTime), pMod.Integer(0)))
+    #
+    # # ensure snmpTrapOID
+    # if len(varBinds) < 2 or varBinds[1][0] != pMod.apiTrapPDU.snmpTrapOID:
+    #     varBinds.insert(0, (ObjectIdentifier(pMod.apiTrapPDU.sysUpTime), pMod.Integer(0)))
+
+    # input PDU is always v2c
+    pMod = api.PROTOCOL_MODULES[api.SNMP_VERSION_2C]
+
+    if notifyType == 'trap':
+        reqPdu = pMod.TrapPDU()
+    else:
+        reqPdu = pMod.InformRequestPDU()
+
+    pMod.apiTrapPDU.setDefaults(reqPdu)
+    pMod.apiTrapPDU.setVarBinds(reqPdu, varBinds)
+
+    if authData.mpModel == 0:
+        reqPdu = rfc2576.v2ToV1(reqPdu)
+
+    future = asyncio.Future()
+
+    snmpDispatcher.sendPdu(authData, transportTarget, reqPdu, cbFun=_cbFun)
+
+    if notifyType == 'trap':
+        def __trapFun(future):
+            if future.cancelled():
+                return
+            future.set_result((None, 0, 0, []))
+
+        loop = asyncio.get_event_loop()
+        loop.call_soon(__trapFun, future)
+
+    return future

--- a/pysnmp/hlapi/v1arch/asyncio/transport.py
+++ b/pysnmp/hlapi/v1arch/asyncio/transport.py
@@ -16,13 +16,13 @@ __all__ = ['Udp6TransportTarget', 'UdpTransportTarget']
 
 
 class UdpTransportTarget(AbstractTransportTarget):
-    """Represent UDP/IPv6 transport endpoint.
+    """Represent UDP/IPv4 transport endpoint.
 
-    This object can be used for passing UDP/IPv6 configuration
+    This object can be used for passing UDP/IPv4 configuration
     information to the
-    :py:class:`~pysnmp.hlapi.v3arch.asyncio.AsyncCommandGenerator` and
-    :py:class:`~pysnmp.hlapi.v3arch.asyncio.AsyncNotificationOriginator`
-    Datastore (LCD) managed by :py:class:`~pysnmp.hlapi.v3arch.SnmpEngine`
+    :py:class:`~pysnmp.hlapi.v1arch.asyncio.AsyncCommandGenerator` and
+    :py:class:`~pysnmp.hlapi.v1arch.asyncio.AsyncNotificationOriginator`
+    objects scheduled on I/O by :py:class:`~pysnmp.hlapi.SnmpDispatcher`
     class instance.
 
     See :RFC:`1906#section-3` for more information on the UDP transport mapping.
@@ -34,9 +34,9 @@ class UdpTransportTarget(AbstractTransportTarget):
         which is a tuple of FQDN, port where FQDN is a string representing
         either hostname or IPv4 address in quad-dotted form, port is an
         integer.
-    timeout: int
+    timeout: :py:class:`int`
         Response timeout in seconds.
-    retries: int
+    retries: :py:class:`int`
         Maximum number of request retries, 0 retries means just a single
         request.
     tagList: str
@@ -46,9 +46,9 @@ class UdpTransportTarget(AbstractTransportTarget):
 
     Examples
     --------
-    >>> from pysnmp.hlapi.asyncio import UdpTransportTarget
+    >>> from pysnmp.hlapi.v1arch.asyncore import UdpTransportTarget
     >>> UdpTransportTarget(('demo.snmplabs.com', 161))
-    UdpTransportTarget(('195.218.195.228', 161), timeout=1, retries=5, tagList='')
+    UdpTransportTarget(('195.218.195.228', 161), timeout=1, retries=5)
     >>>
     """
     TRANSPORT_DOMAIN = udp.domainName
@@ -67,13 +67,13 @@ class UdpTransportTarget(AbstractTransportTarget):
 
 
 class Udp6TransportTarget(AbstractTransportTarget):
-    """Creates UDP/IPv6 configuration entry and initialize socket API if needed.
+    """Represent UDP/IPv6 transport endpoint.
 
-    This object can be used by
-    :py:class:`~pysnmp.hlapi.v3arch.asyncio.AsyncCommandGenerator` or
-    :py:class:`~pysnmp.hlapi.v3arch.asyncio.AsyncNotificationOriginator`
-    and their derivatives for adding new entries to Local Configuration
-    Datastore (LCD) managed by :py:class:`~pysnmp.hlapi.v3arch.SnmpEngine`
+    This object can be used for passing UDP/IPv6 configuration
+    information to the
+    :py:class:`~pysnmp.hlapi.v1arch.asyncio.AsyncCommandGenerator` and
+    :py:class:`~pysnmp.hlapi.v1arch.asyncio.AsyncNotificationOriginator`
+    objects scheduled on I/O by :py:class:`~pysnmp.hlapi.SnmpDispatcher`
     class instance.
 
     See :RFC:`1906#section-3`, :RFC:`2851#section-4` for more information
@@ -81,7 +81,7 @@ class Udp6TransportTarget(AbstractTransportTarget):
 
     Parameters
     ----------
-    transportAddr : tuple
+    transportAddr: tuple
         Indicates remote address in Python :py:mod:`socket` module format
         which is a tuple of FQDN, port where FQDN is a string representing
         either hostname or IPv6 address in one of three conventional forms

--- a/pysnmp/hlapi/v1arch/asyncore/transport.py
+++ b/pysnmp/hlapi/v1arch/asyncore/transport.py
@@ -42,7 +42,6 @@ class UdpTransportTarget(AbstractTransportTarget):
     >>> UdpTransportTarget(('demo.snmplabs.com', 161))
     UdpTransportTarget(('195.218.195.228', 161), timeout=1, retries=5)
     >>>
-
     """
     TRANSPORT_DOMAIN = udp.DOMAIN_NAME
     PROTO_TRANSPORT = udp.UdpSocketTransport


### PR DESCRIPTION
The hlapi.v1arch asyncio API is intended to be very similar to
hlapi.v3arch.asyncio from its signature viewpoint, however it
should be faster at the expense of no SNMPv3 support.