### PR TITLE
Example should use SNMP v2

### DIFF
--- a/examples/hlapi/v3arch/twisted/agent/ntforg/v2c-trap-inline-callbacks.py
+++ b/examples/hlapi/v3arch/twisted/agent/ntforg/v2c-trap-inline-callbacks.py
@@ -26,7 +26,7 @@ def sendtrap(reactor, snmpEngine, hostname):
 
     deferred = sendNotification(
         snmpEngine,
-        CommunityData('public', mpModel=0),
+        CommunityData('public', mpModel=1),
         UdpTransportTarget((hostname, 162)),
         ContextData(),
         'trap',


### PR DESCRIPTION
This change makes the example send a v2 trap, previously it would send a v1 trap.

I thought about completely removing the `mpModel` argument (since it defaults to `1`), but having it explicitly stated helps to figure out its purpose (when compared with the example rendered above it in https://github.com/etingof/pysnmp/blob/master/docs/source/examples/hlapi/v3arch/twisted/agent/ntforg/common-notifications.rst)