### PR TITLE
Remove unnecessary except and reraise of KeyboardInterrupt.

### DIFF
--- a/pysnmp/carrier/asyncore/dispatch.py
+++ b/pysnmp/carrier/asyncore/dispatch.py
@@ -46,9 +46,6 @@ class AsyncoreDispatcher(AbstractTransportDispatcher):
                 loop(timeout or self.getTimerResolution(),
                      use_poll=True, map=self.__sockMap, count=1)
 
-            except KeyboardInterrupt:
-                raise
-
             except Exception:
                 raise PySnmpError(
                     'poll error: %s' % ';'.join(format_exception(*exc_info())))


### PR DESCRIPTION
KeyboardInterrupt is not derived from Exception, so it is not necessary
to have an explicit except KeyboardInterrupt:.

Prior commit 588b9b902d19 ("Uppercase global constants (#238)") changed
a bare except: to except Exception:.  In doing so it made the explicit
catch and reraise of KeyboardInterrupt unnecessary.