### PR TITLE
Introduce "wildcard" SNMP engine ID

### DIFF
--- a/pysnmp/hlapi/auth.py
+++ b/pysnmp/hlapi/auth.py
@@ -305,11 +305,6 @@ class UsmUserData(object):
         * :py:class:`~pysnmp.hlapi.usmKeyTypeMaster`
         * :py:class:`~pysnmp.hlapi.usmKeyTypeLocalized`
 
-
-        If `~pysnmp.hlapi.usmKeyTypeLocalized` is used, peer SNMP engine ID
-        discovery mechanism can't be leveraged for key localization, so
-        *securityEngineId* must be given by local configuration.
-
     privKeyType: :py:class:`int`
         Type of `privKey` material. See :RFC:`3414#section-2.6` for
         technical explanation.
@@ -320,6 +315,21 @@ class UsmUserData(object):
         * :py:class:`~pysnmp.hlapi.usmKeyTypeMaster`
         * :py:class:`~pysnmp.hlapi.usmKeyTypeLocalized`
 
+    Notes
+    -----
+    If `~pysnmp.hlapi.usmKeyTypeLocalized` is used when running a
+    non-authoritative SNMP engine, USM key localization mechanism
+    is not invoked. As a consequence, local SNMP engine configuration
+    won't get automatically populated with remote SNMP engine's
+    *securityEngineId*.
+
+    Therefore peer SNMP engine's *securityEngineId* must be added
+    to local configuration and associated with its localized keys.
+
+    Alternatively, the magic *securityEngineId* value of five zeros
+    (*0x0000000000*) can be used to refer to the localized keys that
+    should be used with any unknown remote SNMP engine. This feature
+    is specific to pysnmp.
 
     Examples
     --------


### PR DESCRIPTION
This change introduces "wildcard" SNMP engine ID (0x00000000). Right
before deciding on firing up SNMP engine ID discovery and key
localization procedure, originating SNMP engine will check for
the presence of this magical engine ID (5 zeros), if it is present
in LCD along with the user name being used, localized keys from that
entry will be used.

Does this have security implications?