### PR TITLE
setup.py: Improve the setuptools version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ try:
 
     setup, Command = setuptools.setup, setuptools.Command
 
-    observed_version = [int(x) for x in setuptools.__version__.split('.')]
+    observed_version = [int(x) for x in setuptools.__version__.split('.')[:3]]
     required_version = [36, 2, 0]
 
     # NOTE(etingof): require fresh setuptools to build proper wheels


### PR DESCRIPTION
On my system (NixOS) the old version check caused problems after
`setuptools.__version__` changed from "41.2.0" to "41.4.0.post20191022" [0].

```
Executing setuptoolsBuildPhase
Traceback (most recent call last):
  File "nix_run_setup", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "setup.py", line 66, in <module>
    observed_version = [int(x) for x in setuptools.__version__.split('.')]
  File "setup.py", line 66, in <listcomp>
    observed_version = [int(x) for x in setuptools.__version__.split('.')]
ValueError: invalid literal for int() with base 10: 'post20191022'
```

But normally the `.post20191022` suffix probably shouldn't be there (at least for releases, but strangely this happened with setuptools version 41.4.0 from PyPI).

[0]: https://hydra.nixos.org/build/104594339/nixlog/2/tail