### PR TITLE
Pass ignoreErrors in unmakeVarBinds

### DIFF
--- a/pysnmp/hlapi/varbinds.py
+++ b/pysnmp/hlapi/varbinds.py
@@ -55,7 +55,7 @@ class CommandGeneratorVarBinds(MibViewControllerManager):
             mibViewController = self.getMibViewController(userCache)
             varBinds = [
                 ObjectType(ObjectIdentity(x[0]),
-                           x[1]).resolveWithMib(mibViewController)
+                           x[1]).resolveWithMib(mibViewController, ignoreErrors=False)
                 for x in varBinds]
 
         return varBinds
@@ -96,7 +96,7 @@ class NotificationOriginatorVarBinds(MibViewControllerManager):
             mibViewController = self.getMibViewController(userCache)
             varBinds = [
                 ObjectType(ObjectIdentity(x[0]),
-                           x[1]).resolveWithMib(mibViewController)
+                           x[1]).resolveWithMib(mibViewController, ignoreErrors=False)
                 for x in varBinds]
 
         return varBinds


### PR DESCRIPTION
This reverts the behavior to pre 4.4.10.

Fixes #329 