### PR TITLE
localkey.py: passwordToKeySHA calls hashPassphraseSHA

### DIFF
--- a/pysnmp/proto/secmod/rfc3414/localkey.py
+++ b/pysnmp/proto/secmod/rfc3414/localkey.py
@@ -68,7 +68,7 @@ def passwordToKeyMD5(passphrase, snmpEngineId):
 
 
 def passwordToKeySHA(passphrase, snmpEngineId):
-    return localizeKey(hashPassphraseMD5(passphrase), snmpEngineId, sha1)
+    return localizeKey(hashPassphraseSHA(passphrase), snmpEngineId, sha1)
 
 
 def localizeKeyMD5(passKey, snmpEngineId):


### PR DESCRIPTION
passwordToKeySHA has called hashPassphraseMD5 to generate its Ku hashPassphraseMD5 since 130bdaa. This is incorrect under RFC 3414 A.2.2, which uses SHA for both Ku and Kul.  
Fortunately, none of the passwordToKey calls are used in the actual library, so this isn't a super urgent fix.

