### PR TITLE
Fix incorrect example in pysnmp.smi.rfc1902.ObjectType.resolveWithMib

### DIFF
--- a/pysnmp/smi/rfc1902.py
+++ b/pysnmp/smi/rfc1902.py
@@ -940,8 +940,9 @@ class ObjectType(object):
 
         Examples
         --------
-        >>> from pysmi.hlapi import varbinds
-        >>> mibViewController = varbinds.AbstractVarBinds.getMibViewController( engine )
+        >>> from pysnmp.hlapi import varbinds
+        >>> from pysnmp.entity.engine import SnmpEngine
+        >>> mibViewController = varbinds.AbstractVarBinds.getMibViewController(SnmpEngine())
         >>> objectType = ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr'), 'Linux i386')
         >>> objectType.resolveWithMib(mibViewController)
         ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr'), DisplayString('Linux i386'))


### PR DESCRIPTION
Corrects a typo in the example code for the `resolveWithMib` method of the `ObjectType` class. The previous example incorrectly referenced `pysmi` instead of `pysnmp`. Additionally, the code has been improved to use `SnmpEngine()` directly, providing better clarity regarding the object being passed to `getMibViewController`.

Previous example:
```Python
def resolveWithMib(self, mibViewController, ignoreErrors=True):
    """Perform MIB variable ID and associated value conversion.
    ....
    Examples
    --------
    >>> from pysmi.hlapi.asyncio import varbinds
    >>> mibViewController = varbinds.AbstractVarBinds.getMibViewController( engine )
    >>> objectType = ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr'), 'Linux i386')
    >>> objectType.resolveWithMib(mibViewController)
    ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr'), DisplayString('Linux i386'))
    >>> str(objectType)
    'SNMPv2-MIB::sysDescr."0" = Linux i386'
    >>>

    """
```

Correct example:
```Python
def resolveWithMib(self, mibViewController, ignoreErrors=True):
    """Perform MIB variable ID and associated value conversion.
    ....
    Examples
    --------
    >>> from pysnmp.hlapi import varbinds
    >>> from pysnmp.entity.engine import SnmpEngine
    >>> mibViewController = varbinds.AbstractVarBinds.getMibViewController(SnmpEngine())
    >>> objectType = ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr'), 'Linux i386')
    >>> objectType.resolveWithMib(mibViewController)
    ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr'), DisplayString('Linux i386'))
    >>> str(objectType)
    'SNMPv2-MIB::sysDescr."0" = Linux i386'
    >>>

    """
```